### PR TITLE
Add de/es/it translations for `quality-control` tutorial

### DIFF
--- a/topics/sequence-analysis/tutorials/quality-control/de/tutorial.md
+++ b/topics/sequence-analysis/tutorials/quality-control/de/tutorial.md
@@ -1,0 +1,1112 @@
+---
+layout: tutorial_hands_on
+title: Qualitätskontrolle
+zenodo_link: https://zenodo.org/records/61771
+questions:
+- How to perform quality control of NGS raw data?
+- What are the quality parameters to check for a dataset?
+- How to improve the quality of a dataset?
+objectives:
+- Assess short reads FASTQ quality using FASTQE 🧬😎 and FastQC
+- Assess long reads FASTQ quality using Nanoplot and PycoQC
+- Perform quality correction with Cutadapt (short reads)
+- Summarise quality metrics MultiQC
+- Process single-end and paired-end data
+follow_up_training:
+- type: internal
+  topic_name: sequence-analysis
+  tutorials:
+  - mapping
+time_estimation: 1H30M
+level: Introductory
+subtopic: basics
+key_points:
+- Perform quality control on every dataset before running any other bioinformatics
+  analysis
+- Assess the quality metrics and improve quality if necessary
+- Check the impact of the quality control
+- Different tools are available to provide additional quality metrics
+- For paired-end reads analyze the forward and reverse reads together
+contributions:
+  authorship:
+  - bebatut
+  - mblue9
+  - alexcorm
+  - abretaud
+  - lleroi
+  - r1corre
+  - stephanierobin
+  - neoformit
+  editing:
+  - Swathi266
+  funding:
+  - gallantries
+recordings:
+- youtube_id: coaMGvZazoc
+  length: 50M
+  speakers:
+  - LonsBio
+  captioners:
+  - LonsBio
+  date: '2023-05-19'
+- captioners:
+  - bebatut
+  - nagoue
+  - shiltemann
+  date: '2021-02-15'
+  galaxy_version: '21.01'
+  length: 1H10M
+  youtube_id: QJRlX2hWDKM
+  speakers:
+  - heylf
+- youtube_id: uiWZea53QIA
+  length: 51M
+  galaxy_version: 24.1.2.dev0
+  date: '2024-09-30'
+  speakers:
+  - dianichj
+  captioners:
+  - dianichj
+  bot-timestamp: 1727710795
+---
+
+
+
+
+Bei der Sequenzierung werden die Nukleotidbasen in einer DNA- oder RNA-Probe (Bibliothek) durch den Sequenzierer bestimmt. Für jedes Fragment in der Bibliothek wird eine Sequenz erzeugt, auch **Leseprobe** genannt, die einfach eine Folge von Nukleotiden ist.
+
+Moderne Sequenzierungstechnologien können in einem einzigen Experiment eine riesige Anzahl von Sequenz-Reads erzeugen. Allerdings ist keine Sequenzierungstechnologie perfekt, und jedes Gerät erzeugt unterschiedliche Arten und Mengen von Fehlern, wie z. B. falsch bezeichnete Nukleotide. Diese falsch benannten Basen sind auf die technischen Beschränkungen der einzelnen Sequenzierplattformen zurückzuführen.
+
+Daher ist es notwendig, Fehlertypen zu verstehen, zu identifizieren und auszuschließen, die die Interpretation der nachgeschalteten Analyse beeinträchtigen können. Die Qualitätskontrolle der Sequenzen ist daher ein wesentlicher erster Schritt in Ihrer Analyse. Frühzeitiges Erkennen von Fehlern spart später Zeit.
+
+> <agenda-title></agenda-title>
+> 
+> In diesem Tutorium werden wir uns mit folgenden Themen beschäftigen:
+> 
+> 1. TOC {:toc}
+> 
+{: .agenda}
+
+# Untersuchen Sie eine Rohsequenzdatei
+
+> <hands-on-title>Daten-Upload</hands-on-title>
+> 
+> 1. Erstellen Sie einen neuen Verlauf für dieses Tutorial und geben Sie ihm einen passenden Namen
+> 
+>    {% snippet faqs/galaxy/histories_create_new.md %}
+> 
+>    {% snippet faqs/galaxy/histories_rename.md %}
+> 
+> 2. Importieren Sie die Datei `female_oral2.fastq-4143.gz` von [Zenodo] (https://zenodo.org/record/3977236) oder aus der Datenbibliothek (fragen Sie Ihren Dozenten) Dies ist eine Mikrobiomprobe von einer Schlange {% cite StJacques2021 %}.
+> 
+>    ```
+>    https://zenodo.org/record/3977236/files/female_oral2.fastq-4143.gz
+>    ```
+> 
+>    {% snippet faqs/galaxy/datasets_import_via_link.md %}
+> 
+>    {% snippet faqs/galaxy/datasets_import_from_data_library.md %}
+> 
+> 3. Benennen Sie den importierten Datensatz in `Reads` um.
+> 
+{: .hands_on}
+
+Wir haben gerade eine Datei in Galaxy importiert. Diese Datei ähnelt den Daten, die wir direkt von einer Sequenziereinrichtung erhalten könnten: eine [FASTQ-Datei](https://en.wikipedia.org/wiki/FASTQ_format).
+
+> <hands-on-title>Inspect the FASTQ file</hands-on-title>
+> 
+> 1. Überprüfen Sie die Datei, indem Sie auf das {% icon galaxy-eye %} (Auge) Symbol
+> 
+{: .hands_on}
+
+Obwohl es kompliziert aussieht (und es vielleicht auch ist), ist das FASTQ-Format mit ein wenig Dekodierung leicht zu verstehen.
+
+Jeder Read, der ein Fragment der Bibliothek darstellt, wird durch 4 Zeilen kodiert:
+
+| Line | Description                                                                                                                                                        |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1    | Always begins with `@` followed by the information about the read                                                                                                  |
+| 2    | The actual nucleic sequence                                                                                                                                        |
+| 3    | Always begins with a `+` and contains sometimes the same info in line 1                                                                                            |
+| 4    | Has a string of characters which represent the quality scores associated with each base of the nucleic sequence; must have the same number of characters as line 2 |
+
+Die erste Sequenz in unserer Datei ist also zum Beispiel:
+
+```
+@M00970:337:000000000-BR5KF:1:1102:17745:1557 1:N:0:CGCAGAAC+ACAGAGTT
+GTGCCAGCCGCCGCGGTAGTCCGACGTGGCTGTCTCTTATACACATCTCCGAGCCCACGAGACCGAAGAACATCTCGTATGCCGTCTTCTGCTTGAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAGAAGCAAATGACGATTCAAGAAAGAAAAAAACACAGAATACTAACAATAAGTCATAAACATCATCAACATAAAAAAGGAAATACACTTACAACACATATCAATATCTAAAATAAATGATCAGCACACAACATGACGATTACCACACATGTGTACTACAAGTCAACTA
++
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGFGGGFGGGGGGAFFGGFGGGGGGGGFGGGGGGGGGGGGGGFGGG+38+35*311*6,,31=******441+++0+0++0+*1*2++2++0*+*2*02*/***1*+++0+0++38++00++++++++++0+0+2++*+*+*+*+*****+0**+0**+***+)*.***1**//*)***)/)*)))*)))*),)0(((-((((-.(4(,,))).,(())))))).)))))))-))-(
+```
+
+Das bedeutet, dass das Fragment mit der Bezeichnung `@M00970` der DNA-Sequenz `GTGCCAGCCGCCGCGGTAGTCCGACGTGGCTGTCTCTTATACACATCTCCGAGCCCACGAGACCGAAGAACATCTCGTATGCCGTCTTCTGCTTGAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAGAAGCAAATGACGATTCAAGAAAGAAAAAAACACAGAATACTAACAATAAGTCATAAACATCATCAACATAAAAAAGGAAATACACTTACAACACATATCAATATCTAAAATAAATGATCAGCACACAACATGACGATTACCACACATGTGTACTACAAGTCAACTA` entspricht und diese Sequenz mit einer Qualität von `GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGFGGGFGGGGGGAFFGGFGGGGGGGGFGGGGGGGGGGGGGGFGGG+38+35*311*6,,31=******441+++0+0++0+*1*2++2++0*+*2*02*/***1*+++0+0++38++00++++++++++0+0+2++*+*+*+*+*****+0**+0**+***+)*.***1**//*)***)/)*)))*)))*),)0(((-((((-.(4(,,))).,(())))))).)))))))-))-(` sequenziert wurde.
+
+{% snippet topics/sequence-analysis/faqs/quality_score.md %}
+
+> <question-title></question-title>
+> 
+> 1. Welches ASCII-Zeichen entspricht dem schlechtesten Phred-Score für Illumina 1.8+?
+> 2. Wie hoch ist der Phred-Qualitätsscore des 3. Nukleotids der ersten Sequenz?
+> 3. Wie berechnet man die Genauigkeit der Nukleotidbase mit dem ASCII-Code `/`?
+> 4. Wie hoch ist die Genauigkeit dieses 3. Nukleotids?
+> 
+> > <solution-title></solution-title>
+> > 1. Der schlechteste Phred-Score ist der kleinste, also 0. Bei Illumina 1.8+ entspricht er dem Zeichen `!`.
+> > 2. Das 3. Nukleotid der 1. Sequenz hat ein ASCII-Zeichen `G`, was einem Score von 38 entspricht.
+> > 3. Dies kann wie folgt berechnet werden:
+> >    - ASCII-Code für `/` ist 47
+> >    - Qualitätsbewertung = 47-33=14
+> >    - Formel zur Ermittlung der Fehlerwahrscheinlichkeit: \\(P = 10^{-Q/10}\)
+> >    - Fehlerwahrscheinlichkeit = (10^{-14/10}\) = 0,03981
+> >    - Daher Genauigkeit = 100 - 0.03981 = 99.96%
+> > 4. Das entsprechende Nukleotid `G` hat eine Genauigkeit von fast 99,96 %
+> > 
+> {: .solution }
+> 
+{: .question}
+
+> <comment-title></comment-title> Das aktuelle lllumina (1.8+) verwendet das Sanger-Format (Phred+33). Wenn Sie mit älteren Datensätzen arbeiten, können Sie auf die älteren Scoring-Schemata stoßen. *mit *FastQC** {% icon tool %}, einem Tool, das wir später in diesem Tutorial verwenden werden, kann versucht werden, die Art der verwendeten Qualitätskodierung zu bestimmen (durch Bewertung des Bereichs der Phred-Werte in der FASTQ).
+> 
+{: .comment}
+
+Wenn man sich die Datei in Galaxy ansieht, sieht es so aus, als ob die meisten Nukleotide einen hohen Score haben (`G` entspricht einem Score von 38). Gilt das für alle Sequenzen? Und entlang der gesamten Sequenzlänge?
+
+
+# Bewertung der Qualität mit FASTQE 🧬😎 - nur kurze Reads
+
+Um einen Blick auf die Sequenzqualität entlang aller Sequenzen zu werfen, können wir [FASTQE](https://fastqe.com/) verwenden. Es ist ein Open-Source-Tool, das eine einfache und unterhaltsame Möglichkeit zur Qualitätskontrolle von Rohsequenzdaten bietet und diese als Emoji ausgibt. Sie können es verwenden, um einen schnellen Eindruck davon zu bekommen, ob Ihre Daten irgendwelche Probleme aufweisen, auf die Sie achten sollten, bevor Sie eine weitere Analyse durchführen.
+
+> <hands-on-title>Qualitätsprüfung</hands-on-title>
+> 
+> 1. {% tool [FASTQE](toolshed.g2.bx.psu.edu/repos/iuc/fastqe/fastqe/0.3.1+galaxy0) %} mit den folgenden Parametern
+>    - {% icon param-files %} *"FastQ-Daten "*: `Reads`
+>    - {% icon param-select %} *"Anzuzeigende Score-Typen "*: `Mean`
+> 
+> 2. Prüfen Sie die generierte HTML-Datei
+> 
+{: .hands_on}
+
+Anstatt die Qualitätswerte für jeden einzelnen Read zu betrachten, betrachtet FASTQE die Qualität kollektiv für alle Reads innerhalb einer Probe und kann den Mittelwert für jede Nukleotidposition entlang der Länge der Reads berechnen. Nachfolgend sind die Mittelwerte für diesen Datensatz aufgeführt.
+
+![FASTQE before](../../images/quality-control/fastqe-mean-before.png "FASTQE mean scores")
+
+Sie können den Score für jedes [Emoji in der fastqe-Dokumentation] sehen (https://github.com/fastqe/fastqe#scale). Die folgenden Emojis mit Phred-Scores unter 20 sind diejenigen, von denen wir hoffen, dass wir sie nicht oft sehen werden.
+
+| Phred Quality Score | ASCII code | Emoji |
+| ------------------- | ---------- | ----- |
+| 0                   | !          | 🚫     |
+| 1                   | "          | ❌     |
+| 2                   | #          | 👺     |
+| 3                   | $          | 💔     |
+| 4                   | %          | 🙅     |
+| 5                   | &          | 👾     |
+| 6                   | '          | 👿     |
+| 7                   | (          | 💀     |
+| 8                   | )          | 👻     |
+| 9                   | *          | 🙈     |
+| 10                  | +          | 🙉     |
+| 11                  | ,          | 🙊     |
+| 12                  | -          | 🐵     |
+| 13                  | .          | 😿     |
+| 14                  | /          | 😾     |
+| 15                  | 0          | 🙀     |
+| 16                  | 1          | 💣     |
+| 17                  | 2          | 🔥     |
+| 18                  | 3          | 😡     |
+| 19                  | 4          | 💩     |
+
+
+> <question-title></question-title>
+> 
+> Was ist der niedrigste Durchschnittswert in diesem Datensatz?
+> 
+> > <solution-title></solution-title> Der niedrigste Wert in diesem Datensatz ist 😿 13.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+
+# Bewertung der Qualität mit FastQC - kurze und lange Reads
+
+Eine zusätzliche oder alternative Möglichkeit zur Überprüfung der Sequenzqualität ist [FastQC] (https://www.bioinformatics.babraham.ac.uk/projects/fastqc/). Es bietet eine modulare Reihe von Analysen, die Sie verwenden können, um zu prüfen, ob Ihre Daten Probleme aufweisen, auf die Sie achten sollten, bevor Sie eine weitere Analyse durchführen. Wir können damit zum Beispiel prüfen, ob bekannte Adapter in den Daten vorhanden sind. Wir führen es mit der FASTQ-Datei aus.
+
+> <hands-on-title>Qualitätsprüfung</hands-on-title>
+> 
+> 1. {% tool [FASTQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0) %} mit den folgenden Parametern
+>    - {% icon param-files %} *"Rohe Lesedaten aus Ihrer aktuellen Historie "*: `Reads`
+> 
+> 2. Prüfen Sie die generierte HTML-Datei
+> 
+{: .hands_on}
+
+> <question-title></question-title>
+> 
+> Welche Phred-Kodierung wird in der FASTQ-Datei für diese Sequenzen verwendet?
+> 
+> > <solution-title></solution-title> Die Phred-Scores werden mit `Sanger / Illumina 1.9` (`Encoding` in der oberen Tabelle) kodiert.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+## Qualität der Sequenz pro Base
+
+Mit FastQC können wir die Basenqualität der Reads anhand des Plots für die Sequenzqualität pro Base überprüfen, ähnlich wie wir es mit FASTQE gemacht haben.
+
+![Per base sequence quality](../../images/quality-control/per_base_sequence_quality-before.png "Per base sequence quality")
+
+Auf der x-Achse ist die Basenposition im Read angegeben. In diesem Beispiel enthält die Probe Reads, die bis zu 296 bp lang sind.
+
+> <details-title>Nicht einheitliche x-Achse</details-title>
+> 
+> Die x-Achse ist nicht immer gleichmäßig. Bei langen Leseabschnitten wird ein gewisses Binning angewendet, um die Dinge kompakt zu halten. Wir können das in unserer Probe sehen. Sie beginnt mit einzelnen 1-10 Basen. Danach werden die Basen über ein Fenster mit einer bestimmten Anzahl von Basen gebinnt. Datenbinning bedeutet Gruppierung und ist eine Technik der Datenvorverarbeitung, um die Auswirkungen kleinerer Beobachtungsfehler zu verringern. Die Anzahl der zusammengebinnten Basenpositionen hängt von der Länge des Reads ab. Bei Reads mit einer Länge von mehr als 50bp werden im letzten Teil des Diagramms aggregierte Statistiken für 5bp-Fenster angezeigt. Kürzere Reads haben kleinere Fenster und längere Reads größere Fenster. Das Binning kann bei der Ausführung von FastQC entfernt werden, indem der Parameter "Disable grouping of bases for reads >50bp" auf Yes gesetzt wird.
+> 
+{: .details}
+
+Für jede Position wird ein Boxplot mit gezeichnet:
+
+- der Medianwert, dargestellt durch die zentrale rote Linie
+- der Interquartilsbereich (25-75%), dargestellt durch den gelben Kasten
+- die 10%- und 90%-Werte in den oberen und unteren Whiskern
+- die mittlere Qualität, dargestellt durch die blaue Linie
+
+Die y-Achse zeigt die Qualitätswerte an. Je höher die Punktzahl, desto besser ist der Base-Call. Der Hintergrund des Diagramms unterteilt die y-Achse in sehr gute Qualitätswerte (grün), Werte von angemessener Qualität (orange) und Werte von schlechter Qualität (rot).
+
+Bei allen Illumina-Sequenzern ist es normal, dass der mittlere Qualitätswert in den ersten 5-7 Basen niedriger ist und dann ansteigt. Die Qualität der Reads nimmt bei den meisten Plattformen am Ende des Reads ab. Dies ist häufig auf einen Signalabfall oder eine Phasenverschiebung während des Sequenzierungslaufs zurückzuführen. Die jüngsten Entwicklungen in der Sequenzierungschemie haben dies etwas verbessert, aber die Reads sind jetzt länger als je zuvor.
+
+
+> <details-title>Signalabfall und Phasenlage</details-title>
+> 
+> - Signalverfall
+> 
+> Die Intensität des Fluoreszenzsignals nimmt mit jedem Zyklus des Sequenziervorgangs ab. Aufgrund der sich abbauenden Fluorophore wird ein Teil der Stränge im Cluster nicht verlängert. Der Anteil des emittierten Signals nimmt mit jedem Zyklus weiter ab, was zu einer Verringerung der Qualitätswerte am 3'-Ende des Read führt.
+> 
+> - Phasierung
+> 
+> Das Signal beginnt mit zunehmender Zykluszahl zu verschwimmen, weil der Cluster an Synchronität verliert. Im Laufe der Zyklen kommt es bei einigen Strängen zu zufälligen Ausfällen bei der Einbindung von Nukleotiden aufgrund von:
+> 
+>  - Unvollständige Entfernung der 3'-Terminatoren und Fluorophore
+>  - Einbau von Nukleotiden ohne wirksame 3'-Terminatoren
+> 
+> Dies führt zu einer Verringerung der Qualitätswerte am 3'-Ende des Reads.
+> 
+{: .details}
+
+
+> <details-title>Andere Sequenzqualitätsprofile</details-title>
+> 
+> Dies sind einige Qualitätsprofile pro Basensequenz, die auf Probleme mit der Sequenzierung hinweisen können.
+> 
+> - Overclustering
+> 
+>   Sequenziereinrichtungen können die Fließzellen überclustern. Dies führt zu geringen Abständen zwischen den Clustern und einer Überlappung der Signale. Zwei Cluster können als ein einziger Cluster interpretiert werden, wobei gemischte Fluoreszenzsignale erkannt werden und die Signalreinheit abnimmt. Dies führt zu niedrigeren Qualitätswerten für den gesamten Read.
+> 
+> - Aufschlüsselung nach Instrumenten
+> 
+>   Während eines Laufs kann es gelegentlich zu Problemen mit den Sequenziergeräten kommen. Ein plötzlicher Qualitätsabfall oder ein hoher Prozentsatz von Reads mit niedriger Qualität im gesamten Read könnte auf ein Problem in der Einrichtung hinweisen. Einige Beispiele für solche Probleme:
+> 
+>    - Manifold Burst
+> 
+>      ![Manifold Burst](../../images/quality-control/per_base_sequence_quality_manifold_burst.png)
+> 
+>    - Zyklenverlust
+> 
+>      ![Zyklusverlust](../../images/quality-control/per_base_sequence_quality_cycle_loss.png)
+> 
+>    - Read 2 failure
+> 
+>      ![Zyklenverlust](../../images/quality-control/per_base_sequence_quality_read2_failure.png)
+> 
+>   Bei solchen Daten sollte die Sequenziereinrichtung kontaktiert werden, um sie zu besprechen. Oft ist dann eine erneute Sequenzierung erforderlich (und wird unserer Erfahrung nach auch von der Firma angeboten).
+> 
+{: .details}
+
+> <question-title></question-title>
+> 
+> 1. Wie verändert sich der mittlere Qualitätswert entlang der Sequenz?
+> 2. Ist diese Tendenz bei allen Sequenzen zu beobachten?
+> 
+> > <solution-title></solution-title>
+> > 1. Der mittlere Qualitätswert (blaue Linie) fällt etwa in der Mitte dieser Sequenzen ab. Es ist üblich, dass die mittlere Qualität zum Ende der Sequenzen hin abnimmt, da die Sequenzer am Ende mehr falsche Nukleotide einbauen. In dieser Probe gibt es jedoch einen sehr starken Qualitätsabfall ab der Mitte.
+> > 2. Die Box-Plots werden ab Position ~100 immer breiter. Das bedeutet, dass bei vielen Sequenzen die Punktzahl ab der Mitte der Sequenz abfällt. Nach 100 Nukleotiden haben mehr als 10% der Sequenzen Scores unter 20.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+Wenn der Median der Qualität unter einem Phred-Score von ~20 liegt, sollten wir in Erwägung ziehen, Basen schlechter Qualität aus der Sequenz zu entfernen. Wir werden diesen Prozess im Abschnitt Trimmen und Filtern erläutern.
+
+### Adapter Inhalt
+
+![Adapter Content](../../images/quality-control/adapter_content-before.png "Adapter Content")
+
+Die Grafik zeigt den kumulativen Prozentsatz der Reads mit den verschiedenen Adaptersequenzen an jeder Position. Sobald eine Adaptersequenz in einem Read vorkommt, wird sie bis zum Ende des Reads gezählt, so dass der Prozentsatz mit der Readlänge zunimmt. FastQC kann einige Adapter standardmäßig erkennen (z.B. Illumina, Nextera), für andere können wir eine Kontaminanten-Datei als Eingabe für das FastQC-Tool bereitstellen.
+
+Idealerweise sollten Illumina-Sequenzdaten keine Adaptersequenz enthalten. Aber bei langen Reads sind einige der Bibliotheksinserts kürzer als die Leselänge, was zu einem Durchlesen des Adapters am 3'-Ende des Reads führt. Diese Mikrobiom-Probe hat relativ lange Reads und wir können sehen, dass Nextera dapater erkannt wurde.
+
+> <details-title>Sonstige Adapterinhaltsprofile</details-title>
+> 
+> Der Adaptergehalt kann auch bei RNA-Seq-Bibliotheken festgestellt werden, bei denen die Verteilung der Bibliotheksinsertgrößen unterschiedlich ist und wahrscheinlich einige kurze Inserts enthält.
+> 
+> ![Adapterinhalt](../../images/quality-control/adapter_content_rna_seq.png)
+> 
+{: .details}
+
+Wir können ein Trimming-Tool wie Cutadapt einsetzen, um diesen Adapter zu entfernen. Wir werden diesen Prozess im Abschnitt Filter und Trimmen erläutern.
+
+
+> <tip-title>Eine Abkürzung nehmen</tip-title>
+> 
+> In den folgenden Abschnitten werden einige der anderen von FastQC erzeugten Diagramme ausführlich beschrieben. Beachten Sie, dass einige Plots/Module Warnungen ausgeben können, aber für die Art der Daten, mit denen Sie arbeiten, normal sind, wie unten und [in den FASTQC-FAQ](https://rtsf.natsci.msu.edu/genomics/tech-notes/fastqc-tutorial-and-faq/) beschrieben. Die anderen Diagramme geben uns Informationen, um die Qualität der Daten besser zu verstehen und um zu sehen, ob im Labor Änderungen vorgenommen werden können, um in Zukunft Daten von höherer Qualität zu erhalten. Diese Abschnitte sind **optional**, und wenn Sie sie überspringen möchten, können Sie das tun:
+>   - Springen Sie direkt zum [nächsten Abschnitt](#trim-and-filter---short-reads), um mehr über das Trimmen von Paired-End-Daten zu erfahren
+> 
+{: .tip}
+
+### Qualität der Sequenz pro Kachel
+
+Mit diesem Diagramm können Sie die Qualitätswerte der einzelnen Kacheln für alle Ihre Basen betrachten, um festzustellen, ob ein Qualitätsverlust nur mit einem Teil der Fließzelle verbunden ist. Das Diagramm zeigt die Abweichung von der durchschnittlichen Qualität für jede Fließzellenkachel an. Die wärmeren Farben zeigen an, dass die Reads in der jeweiligen Kachel eine schlechtere Qualität für diese Position aufweisen als die Reads in anderen Kacheln. Bei dieser Probe können Sie sehen, dass bestimmte Kacheln durchweg schlechte Qualität aufweisen, insbesondere ab ~100bp. Ein guter Plot sollte durchgängig blau sein.
+
+![Per tile sequence quality](../../images/quality-control/per_tile_sequence_quality-before.png "Per tile sequence quality")
+
+Dieses Diagramm wird nur für Illumina-Bibliotheken angezeigt, die ihre ursprünglichen Sequenzkennungen beibehalten. Darin kodiert ist die Fließzellenkachel, aus der jeder Read stammt.
+
+> <details-title>Andere Kachelqualitätsprofile</details-title>
+> 
+> In einigen Fällen sind die bei der Sequenzierung verwendeten Chemikalien im Laufe der Zeit erschöpft und die letzten Kacheln haben die schlechtesten Chemikalien erhalten, was die Sequenzierungsreaktionen etwas fehleranfällig macht. Das Diagramm "Sequenzqualität pro Kachel" weist dann einige horizontale Linien wie diese auf:
+> 
+> ![Pro Kachel Sequenzqualität mit horizontalen Linien](../../images/quality-control/per_tile_sequence_quality_horizontal_lines.png)
+> 
+{: .details}
+
+## Qualitätswerte pro Sequenz
+
+Auf der x-Achse ist die durchschnittliche Qualitätsbewertung über die gesamte Länge aller Reads aufgetragen, auf der y-Achse die Gesamtzahl der Reads mit dieser Bewertung:
+
+![Per sequence quality scores](../../images/quality-control/per_sequence_quality_scores-before.png "Per sequence quality scores")
+
+Die Verteilung der durchschnittlichen Lesequalität sollte einen engen Peak im oberen Bereich des Diagramms aufweisen. Es kann auch angezeigt werden, wenn eine Teilmenge der Sequenzen durchgängig niedrige Qualitätswerte aufweist: Dies kann vorkommen, weil einige Sequenzen schlecht abgebildet werden (am Rande des Sichtfelds usw.), diese sollten jedoch nur einen kleinen Prozentsatz der gesamten Sequenzen ausmachen.
+
+## Inhalt pro Basensequenz
+
+![Inhalt pro Basensequenz](../../images/quality-control/per_base_sequence_content-before.png "Inhalt pro Basensequenz für eine DNA-Bibliothek")
+
+"Per Base Sequence Content" stellt den prozentualen Anteil jedes der vier Nukleotide (T, C, A, G) an jeder Position über alle Reads in der Eingabesequenzdatei dar. Wie bei der Qualität der Sequenz pro Base ist die x-Achse uneinheitlich.
+
+In einer zufälligen Bibliothek würde man erwarten, dass sich die vier Basen wenig bis gar nicht unterscheiden. Der Anteil jeder der vier Basen sollte über die Länge des Reads mit `%A=%T` und `%G=%C` relativ konstant bleiben, und die Linien in diesem Diagramm sollten parallel zueinander verlaufen. Es handelt sich um Amplikondaten, bei denen 16S-DNA mittels PCR amplifiziert und sequenziert wird. Daher ist zu erwarten, dass diese Darstellung eine gewisse Verzerrung aufweist und keine Zufallsverteilung zeigt.
+
+> <Details-title>Biases nach Bibliothekstyp</details-title>
+> 
+> Es ist erwähnenswert, dass einige Bibliothekstypen immer eine verzerrte Sequenzzusammensetzung erzeugen, normalerweise zu Beginn des Lesevorgangs. Bibliotheken, die durch Priming mit zufälligen Hexameren hergestellt wurden (einschließlich fast aller RNA-Seq-Bibliotheken), und solche, die mit Transposasen fragmentiert wurden, enthalten eine intrinsische Verzerrung an den Positionen, an denen Reads beginnen (die ersten 10-12 Basen). Diese Verzerrung bezieht sich nicht auf eine bestimmte Sequenz, sondern sorgt für eine Anreicherung einer Reihe verschiedener K-Mere am 5'-Ende der Reads. Dies ist zwar ein echter technischer Bias, kann aber nicht durch Trimming korrigiert werden und scheint in den meisten Fällen die nachgeschaltete Analyse nicht zu beeinträchtigen. Es wird jedoch eine Warnung oder ein Fehler in diesem Modul erzeugt.
+> 
+> ![Inhalt pro Basensequenz für RNA-seq-Daten](../../images/quality-control/per_base_sequence_content_rnaseq.png)
+> 
+> Bei ChIP-seq-Daten kann es bei der Fragmentierung mit Transposasen auch zu Verzerrungen der Lesestartsequenz kommen. Bei Bisulfit-konvertierten Daten, z. B. HiC-Daten, wird eine Trennung von G von C und A von T erwartet:
+> 
+> ![Inhalt pro Basensequenz für Bisulfit-Daten](../../images/quality-control/per_base_sequence_content_bisulphite.png)
+> 
+> Am Ende ist eine allgemeine Verschiebung in der Sequenzzusammensetzung festzustellen. Wenn die Verschiebung mit einem Verlust an Sequenzierqualität korreliert, kann vermutet werden, dass Fehlanrufe mit einer gleichmäßigeren Sequenzverzerrung erfolgen als bei bisulfitkonvertierten Bibliotheken. Durch das Trimmen der Sequenzen wurde dieses Problem behoben, aber wenn dies nicht geschehen wäre, hätte es dramatische Auswirkungen auf die durchgeführten Methylierungs-Calls gehabt.
+> 
+{: .details}
+
+> <question-title></question-title>
+> 
+> Warum gibt es eine Warnung bei den Graphen für den Sequenzgehalt pro Base?
+> 
+> > <solution-title></solution-title> Am Anfang der Sequenzen ist der Sequenzgehalt pro Base nicht wirklich gut und die Prozentsätze sind nicht gleich, wie für 16S-Amplikon-Daten erwartet.
+> > 
+> > 
+> {: .solution }
+> 
+{: .question}
+
+
+## GC-Gehalt pro Sequenz
+
+![Per sequence GC content](../../images/quality-control/per_sequence_gc_content-before.png "Per sequence GC content")
+
+Diese Grafik zeigt die Anzahl der Reads im Vergleich zum Prozentsatz der Basen G und C pro Read. Sie wird mit einer theoretischen Verteilung verglichen, die von einem einheitlichen GC-Gehalt aller Reads ausgeht, wie er bei der Shotgun-Sequenzierung des gesamten Genoms erwartet wird, wobei der zentrale Peak dem gesamten GC-Gehalt des zugrunde liegenden Genoms entspricht. Da der GC-Gehalt des Genoms nicht bekannt ist, wird der modale GC-Gehalt aus den beobachteten Daten berechnet und zur Erstellung einer Referenzverteilung verwendet.
+
+Eine ungewöhnlich geformte Verteilung könnte auf eine kontaminierte Bibliothek oder eine andere Art von verzerrter Teilmenge hinweisen. Eine verschobene Normalverteilung deutet auf eine systematische Verzerrung hin, die unabhängig von der Basenposition ist. Wenn es eine systematische Verzerrung gibt, die eine verschobene Normalverteilung erzeugt, wird dies vom Modul nicht als Fehler erkannt, da es nicht weiß, wie hoch der GC-Gehalt Ihres Genoms sein sollte.
+
+Es gibt aber auch andere Situationen, in denen eine ungewöhnlich geformte Verteilung auftreten kann. Bei der RNA-Sequenzierung kann es beispielsweise zu einer mehr oder weniger starken Verteilung des mittleren GC-Gehalts unter den Transkripten kommen, was dazu führt, dass die beobachtete Kurve breiter oder schmaler ist als eine ideale Normalverteilung.
+
+> <question-title></question-title>
+> 
+> Warum sind die Graphen für den GC-Gehalt pro Sequenz fehlerhaft?
+> 
+> > <solution-title></solution-title> Es gibt mehrere Peaks. Dies kann auf unerwartete Kontaminationen wie Adapter, rRNA oder überrepräsentierte Sequenzen hinweisen. Es kann aber auch normal sein, wenn es sich um Amplikon-Daten handelt oder Sie sehr reichhaltige RNA-seq-Transkripte haben.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+### Sequenzlängenverteilung
+
+Diese Grafik zeigt die Verteilung der Fragmentgrößen in der untersuchten Datei. In vielen Fällen ergibt sich ein einfaches Diagramm, das einen Peak nur bei einer Größe zeigt, aber bei FASTQ-Dateien mit variabler Länge zeigt es die relativen Mengen der einzelnen Sequenzfragmente unterschiedlicher Größe. Unser Diagramm zeigt die variable Länge, da wir die Daten getrimmt haben. Der größte Peak liegt bei 296bp, aber es gibt einen zweiten großen Peak bei ~100bp. Obwohl unsere Sequenzen bis zu 296bp lang sind, sind viele der qualitativ hochwertigen Sequenzen kürzer. Dies entspricht dem Abfall der Sequenzqualität bei ~100bp und den roten Streifen, die an dieser Position im Diagramm der Sequenzqualität pro Kachel beginnen.
+
+![Sequenzlängenverteilung](../../images/quality-control/sequence_length_distribution-before.png "Sequenzlängenverteilung")
+
+Einige Hochdurchsatz-Sequenzer erzeugen Sequenzfragmente von einheitlicher Länge, andere können jedoch Reads von sehr unterschiedlicher Länge enthalten. Selbst innerhalb von Bibliotheken mit einheitlicher Länge schneiden einige Pipelines Sequenzen zu, um Basen-Calls von schlechter Qualität vom Ende oder den ersten $$n$$ Basen zu entfernen, wenn sie mit den ersten $$n$$ Basen des Adapters bis zu 90% übereinstimmen (standardmäßig), wobei manchmal $$n = 1$$.
+
+## Sequenzduplikationsstufen
+
+Das Diagramm zeigt in Blau den Prozentsatz der Reads einer bestimmten Sequenz in der Datei, die eine bestimmte Anzahl von Malen in der Datei vorhanden sind:
+
+![Sequenzverdopplungsstufen](../../images/quality-control/sequence_duplication_levels-before.png "Sequenzverdopplungsstufen")
+
+In einer heterogenen Bibliothek werden die meisten Sequenzen nur einmal im endgültigen Satz vorkommen. Eine geringe Duplizierung kann auf einen sehr hohen Abdeckungsgrad der Zielsequenz hinweisen, eine hohe Duplizierung deutet jedoch eher auf eine Art Anreicherungsbias hin.
+
+Es lassen sich zwei Quellen für doppelte Reads finden:
+- PCR-Duplikation, bei der Bibliotheksfragmente aufgrund einer verzerrten PCR-Anreicherung überrepräsentiert sind
+
+  Dies ist besorgniserregend, weil PCR-Duplikate den wahren Anteil der Sequenzen in der Eingabe falsch darstellen.
+
+- Wirklich überrepräsentierte Sequenzen, z. B. sehr häufig vorkommende Transkripte in einer RNA-Seq-Bibliothek oder in Amplikon-Daten (wie diese Probe)
+
+  Dies ist ein erwarteter Fall und nicht besorgniserregend, da er die Eingabe getreu darstellt.
+
+> <details-title>Mehr Details zur Duplikation</details-title>
+> 
+> FastQC zählt den Grad der Duplikation für jede Sequenz in einer Bibliothek und erstellt ein Diagramm, das die relative Anzahl der Sequenzen mit verschiedenen Duplikationsgraden anzeigt. Das Diagramm besteht aus zwei Linien:
+> - Blaue Linie: Verteilung der Duplikationsgrade für den vollständigen Sequenzsatz
+> - Rote Linie: Verteilung der entduplizierten Sequenzen mit den Anteilen der entduplizierten Menge, die aus verschiedenen Duplikationsstufen in den Originaldaten stammen.
+> 
+> Bei Shotgun-Daten für das gesamte Genom ist davon auszugehen, dass nahezu 100 % der Reads einzigartig sind (d. h. nur ein einziges Mal in den Sequenzdaten vorkommen). Die meisten Sequenzen sollten sowohl in der roten als auch in der blauen Linie ganz links im Diagramm liegen. Dies deutet auf eine hochdiverse Bibliothek hin, die nicht übersequenziert wurde. Wenn die Sequenzierungstiefe extrem hoch ist (z. B. > 100x die Größe des Genoms), kann es zu unvermeidlichen Sequenzduplikationen kommen: Theoretisch gibt es nur eine endliche Anzahl von völlig eindeutigen Sequenzlesungen, die aus einer gegebenen Eingangs-DNA-Probe gewonnen werden können.
+> 
+> Spezifischere Anreicherungen von Untergruppen oder das Vorhandensein von Verunreinigungen mit geringer Komplexität führen zu Spitzen auf der rechten Seite des Diagramms. Diese hohen Duplikationspeaks erscheinen meist in der blauen Kurve, da sie einen hohen Anteil der ursprünglichen Bibliothek ausmachen, verschwinden aber normalerweise in der roten Kurve, da sie einen unbedeutenden Anteil der deduplizierten Menge ausmachen. Bleiben die Peaks in der roten Kurve bestehen, deutet dies darauf hin, dass es eine große Anzahl verschiedener hoch duplizierter Sequenzen gibt, was entweder auf einen kontaminierten Satz oder eine sehr starke technische Duplikation hinweisen könnte.
+> 
+> Bei der RNA-Sequenzierung gibt es in der Regel einige sehr häufig vorkommende Transkripte und einige weniger häufig vorkommende. Es ist zu erwarten, dass doppelte Reads für Transkripte mit hoher Häufigkeit beobachtet werden:
+> 
+> ![Sequenzduplikationslevel für RNA-seq](../../images/quality-control/sequence_duplication_levels_rna_seq.png)
+> 
+{: .details}
+
+## Überrepräsentierte Sequenzen
+
+Eine normale Bibliothek mit hohem Durchsatz enthält eine Vielzahl von Sequenzen, wobei keine einzelne Sequenz einen winzigen Bruchteil des Ganzen ausmacht. Die Feststellung, dass eine einzelne Sequenz in der Menge stark überrepräsentiert ist, bedeutet entweder, dass sie biologisch sehr bedeutsam ist, oder sie weist darauf hin, dass die Bibliothek kontaminiert oder nicht so vielfältig ist wie erwartet.
+
+FastQC listet alle Sequenzen auf, die mehr als 0,1 % der Gesamtmenge ausmachen. Für jede überrepräsentierte Sequenz sucht FastQC nach Übereinstimmungen in einer Datenbank mit üblichen Verunreinigungen und meldet den besten gefundenen Treffer. Die Treffer müssen mindestens 20bp lang sein und dürfen nicht mehr als 1 Mismatch aufweisen. Das Auffinden eines Treffers bedeutet nicht unbedingt, dass es sich um die Quelle der Verunreinigung handelt, aber es kann Ihnen einen Hinweis auf die richtige Richtung geben. Es ist auch erwähnenswert, dass viele Adaptersequenzen einander sehr ähnlich sind, so dass ein Treffer gemeldet werden kann, der technisch nicht korrekt ist, aber eine sehr ähnliche Sequenz wie die eigentliche Übereinstimmung aufweist.
+
+RNA-Sequenzierungsdaten können einige Transkripte enthalten, die so häufig vorkommen, dass sie als überrepräsentierte Sequenz registriert werden. Bei DNA-Sequenzierungsdaten sollte keine einzelne Sequenz so häufig vorkommen, dass sie aufgelistet wird, aber wir können manchmal einen kleinen Prozentsatz von Adapter-Reads sehen.
+
+> <question-title></question-title>
+> 
+> Wie können wir herausfinden, welche Sequenzen überrepräsentiert sind?
+> 
+> > <solution-title></solution-title> Wir können überrepräsentierte Sequenzen mit BLAST untersuchen, um zu sehen, um welche es sich handelt. In diesem Fall nehmen wir die am stärksten überrepräsentierte Sequenz
+> > ```
+> > >overrep_seq1
+> > GTGTCAGCCGCCGCGGTAGTCCGACGTGGCTGTCTCTTATACACATCTCC
+> > ```
+> > und [blastn](https://blast.ncbi.nlm.nih.gov/Blast.cgi) gegen die Standard-Nukleotiddatenbank (nr/nt) verwenden, erhalten wir keine Treffer. Aber wenn wir [VecScreen](https://www.ncbi.nlm.nih.gov/tools/vecscreen/) verwenden, sehen wir, dass es der Nextera-Adapter ist. ![VecScreen](../../images/quality-control/vecscreen-nextera.png "Nextera-Adapter")
+> > 
+> {: .solution }
+> 
+{: .question}
+
+
+> <details-title>Mehr Details über andere FastQC-Plots</details-title>
+> 
+> 
+> #### N-Gehalt pro Base
+> 
+> ![Per base N content](../../images/quality-control/per_base_n_content-before.png "Per base N content")
+> 
+> Wenn ein Sequenzer nicht in der Lage ist, einen Base-Call mit ausreichendem Vertrauen durchzuführen, schreibt er ein "N" anstelle eines herkömmlichen Base-Calls. Dieses Diagramm zeigt den Prozentsatz der Basenaufrufe an jeder Position oder jedem Bin an, für die ein "N" aufgerufen wurde.
+> 
+> Es ist nicht ungewöhnlich, dass ein sehr hoher Anteil von Ns in einer Sequenz auftritt, insbesondere gegen Ende der Sequenz. Aber diese Kurve sollte niemals merklich über Null ansteigen. Wenn dies der Fall ist, deutet dies auf ein Problem während des Sequenzierungslaufs hin. Im folgenden Beispiel führte ein Fehler dazu, dass das Gerät bei etwa 20 % der Reads an Position 29 keine Base aufrufen konnte:
+> 
+> ![Inhalt pro Base N](../../images/quality-control/per_base_n_content_error.png)
+> 
+> 
+> #### Kmer-Gehalt
+> 
+> Dieser Plot wird standardmäßig nicht ausgegeben. Wie im Tool-Formular angegeben, muss dieses Modul mit Hilfe eines benutzerdefinierten Submoduls und einer Grenzwertdatei aktiviert werden, wenn Sie es wünschen. Mit diesem Modul führt FastQC eine generische Analyse aller kurzen Nukleotidsequenzen der Länge k (kmer, standardmäßig k = 7) durch, beginnend an jeder Position entlang des Reads in der Bibliothek, um diejenigen zu finden, die keine gleichmäßige Abdeckung über die Länge Ihrer Reads haben. Jedes gegebene kmer sollte gleichmäßig über die Länge des Reads vertreten sein.
+> 
+> FastQC meldet die Liste der kmers, die an bestimmten Positionen mit einer größeren Häufigkeit als erwartet auftreten. Dies kann auf verschiedene Quellen von Verzerrungen in der Bibliothek zurückzuführen sein, einschließlich des Vorhandenseins von Durchlese-Adaptersequenzen, die sich am Ende der Sequenzen ansammeln. Das Vorhandensein von überrepräsentierten Sequenzen in der Bibliothek (z. B. Adapterdimere) führt dazu, dass das Kmer-Diagramm von den Kmer-Werten dieser Sequenzen dominiert wird. Kmer, die aufgrund anderer interessanter Verzerrungen verzerrt sind, können dann verwässert werden und sind nicht leicht zu erkennen.
+> 
+> Das folgende Beispiel stammt aus einer hochwertigen DNA-Seq-Bibliothek. Die verzerrten kmers in der Nähe des Lesebeginns sind wahrscheinlich auf eine geringe sequenzabhängige Effizienz der DNA-Scherung oder auf ein zufälliges Priming zurückzuführen:
+> 
+> ![Kmer Content](../../images/quality-control/kmer_content.png "Kmer content")
+> 
+> Dieses Modul kann sehr schwer zu interpretieren sein. Der Adapter-Content-Plot und die Tabelle der überrepräsentierten Sequenzen sind einfacher zu interpretieren und können Ihnen genügend Informationen liefern, ohne dass Sie diesen Plot benötigen. RNA-seq-Bibliotheken können stark vertretene kmers haben, die von hoch exprimierten Sequenzen stammen. Um mehr über diese Darstellung zu erfahren, lesen Sie bitte die [FastQC Kmer Content documentation](http://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/11%20Kmer%20Content.html).
+> 
+{: .details}
+
+Wir haben versucht, hier verschiedene FastQC-Berichte und einige Anwendungsfälle zu erklären. Mehr darüber und auch einige häufige Probleme bei der Sequenzierung der nächsten Generation finden Sie auf [QCFAIL.com](https://sequencing.qcfail.com/)
+
+> <details-title>Spezifisches Problem bei alternativen Bibliothekstypen</details-title>
+> 
+> #### Kleine/Mikro-RNA
+> 
+> In kleinen RNA-Bibliotheken haben wir in der Regel einen relativ kleinen Satz einzigartiger, kurzer Sequenzen. Kleine RNA-Bibliotheken werden vor dem Hinzufügen von Sequenzieradaptern an ihren Enden nicht zufällig geschert: Alle Reads für bestimmte Klassen von microRNAs werden identisch sein. Das Ergebnis wird sein:
+> 
+> - Extrem verzerrter Inhalt pro Basensequenz
+> - Äußerst enge Verteilung des GC-Gehalts
+> - Sehr hohe Sequenzduplikationsraten
+> - Häufigkeit der überrepräsentierten Sequenzen
+> - Durchlesen in Adaptern
+> 
+> #### Amplikon
+> 
+> Amplikon-Bibliotheken werden durch PCR-Amplifikation eines bestimmten Ziels hergestellt. Zum Beispiel die hypervariable Region V4 des bakteriellen 16S rRNA-Gens. Es wird erwartet, dass alle Reads aus dieser Art von Bibliothek nahezu identisch sind. Das Ergebnis wird sein:
+> 
+> - Extrem verzerrter Inhalt pro Basensequenz
+> - Äußerst enge Verteilung des GC-Gehalts
+> - Sehr hohe Sequenzduplikationsraten
+> - Häufigkeit der überrepräsentierten Sequenzen
+> 
+> #### Bisulfit- oder Methylierungssequenzierung
+> 
+> Bei der Bisulfit- oder Methylierungssequenzierung wird die Mehrzahl der Cytosinbasen (C) in Thyminbasen (T) umgewandelt. Das Ergebnis ist:
+> 
+> - Verzerrter Inhalt pro Basensequenz
+> - Verzerrter GC-Gehalt pro Sequenz
+> 
+> #### Adapter-Dimer-Kontamination
+> 
+> Jeder Bibliothekstyp kann einen sehr geringen Prozentsatz von Adapter-Dimer-Fragmenten (d. h. ohne Insert) enthalten. Sie sind eher in Amplikon-Bibliotheken zu finden, die vollständig durch PCR (durch Bildung von PCR-Primer-Dimern) aufgebaut sind, als in DNA-Seq- oder RNA-Seq-Bibliotheken, die durch Adapter-Ligation aufgebaut sind. Wenn ein ausreichender Anteil der Bibliothek aus Adapter-Dimeren besteht, wird dies im FastQC-Bericht sichtbar:
+> 
+> - Abfall der Sequenzqualität pro Base nach Base 60
+> - Mögliche bimodale Verteilung der Qualitätswerte pro Sequenz
+> - Ausgeprägtes Muster im Sequenzgehalt pro Base bis zur Base 60
+> - Spike im GC-Gehalt pro Sequenz
+> - Überrepräsentierte Sequenz mit passendem Adapter
+> - Adaptergehalt > 0% ab Basis 1
+> 
+{: .details}
+
+> <comment-title>Schlechte Qualität der Sequenzen</comment-title> Wenn die Qualität der Reads nicht gut ist, sollten wir immer zuerst prüfen, was falsch ist und darüber nachdenken: Es kann an der Art der Sequenzierung liegen oder an dem, was wir sequenziert haben (hohe Anzahl überrepräsentierter Sequenzen in Transkriptomikdaten, verzerrter Prozentsatz von Basen in HiC-Daten).
+> 
+> Sie können sich auch an die Sequenziereinrichtung wenden, insbesondere wenn die Qualität wirklich schlecht ist: Die Qualitätsbehandlungen können nicht alles lösen. Wenn zu viele Basen von schlechter Qualität weggeschnitten werden, werden die entsprechenden Reads herausgefiltert und Sie verlieren sie.
+> 
+{: .comment}
+
+# Trimmen und Filtern - kurze Reads
+
+Die Qualität nimmt in der Mitte dieser Sequenzen ab. Dies könnte bei nachgelagerten Analysen zu Verzerrungen durch diese möglicherweise falsch benannten Nukleotide führen. Die Sequenzen müssen behandelt werden, um eine Verzerrung in der nachgelagerten Analyse zu vermeiden. Trimming kann dazu beitragen, die Anzahl der Reads zu erhöhen, die der Aligner oder Assembler erfolgreich nutzen kann, und die Anzahl der nicht gemappten oder nicht assemblierten Reads zu verringern. Im Allgemeinen umfassen die Qualitätsbehandlungen:
+
+1. Trimmen/Schneiden/Maskieren von Sequenzen
+    - aus Regionen mit niedriger Qualitätsbewertung
+    - Anfang/Ende der Sequenz
+    - Entfernen von Adaptern
+2. Filterung von Sequenzen
+    - mit niedriger mittlerer Qualitätsbewertung
+    - zu kurz
+    - mit zu vielen mehrdeutigen (N) Basen
+
+Um diese Aufgabe zu bewältigen, werden wir [Cutadapt](https://cutadapt.readthedocs.io/en/stable/guide.html) {% cite marcel2011cutadapt %} verwenden, ein Tool, das die Sequenzqualität durch automatisiertes Adapter-Trimming und Qualitätskontrolle verbessert. Wir werden:
+
+- Trimmen von Basen geringer Qualität an den Enden. Das Qualitätstrimming wird vor dem Adaptertrimming durchgeführt. Wir setzen den Qualitätsschwellenwert auf 20, ein häufig verwendeter Schwellenwert, siehe mehr [in GATK's Phred Score FAQ](https://gatk.broadinstitute.org/hc/en-us/articles/360035531872-Phred-scaled-quality-scores).
+- Trimmen des Adapters mit Cutadapt. Dazu müssen wir die Sequenz des Adapters angeben. In diesem Beispiel ist Nextera der Adapter, der erkannt wurde. Wir können die Sequenz des Nextera-Adapters auf der [Illumina-Website hier](https://support.illumina.com/bulletins/2016/12/what-sequences-do-i-use-for-adapter-trimming.html) `CTGTCTCTTATACACATCT` finden. Wir werden diese Sequenz vom 3'-Ende der Reads abschneiden.
+- Herausfiltern von Sequenzen mit einer Länge < 20 nach dem Trimmen
+
+> <hands-on-title>Verbesserung der Sequenzqualität</hands-on-title>
+> 
+> 1. {% tool [Cutadapt](toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.9+galaxy1) %} mit den folgenden Parametern
+>    - *"Single-end or Paired-end reads? "*: `Single-end`
+>       - {% icon param-file %} *"FASTQ/A-Datei "*: `Reads` (Eingabe-Datensatz)
+> 
+>         > <tip-title>Dateien nicht auswählbar?</tip-title> Wenn Ihre FASTQ-Datei nicht ausgewählt werden kann, können Sie überprüfen, ob das Format FASTQ mit Sanger-skalierten Qualitätswerten (`fastqsanger.gz`) ist. Sie können den Datentyp bearbeiten, indem Sie auf das Bleistiftsymbol klicken.
+> > 
+>          {: .tip}
+> 
+>    - In *"Read 1 Adapters "*:
+>       - *"1: 3' (End) Adapter "*:
+>          - *"Quelle "*: `Enter custom sequence`
+>          - *"Benutzerdefinierte 3'-Adaptersequenz "*: `CTGTCTCTTATACACATCT`
+>    - In *"Other Read Trimming Options "*
+>       - *"Quality cutoff(s) (R1) "*: `20`
+>    - In *"Read Filtering Options "*
+>       - *"Mindestlänge (R1) "*: `20`
+>    - {% icon param-select %} *"Zusätzliche zu erzeugende Ausgaben "*: `Report`
+> 
+> 2. Prüfen Sie die erzeugte txt-Datei (`Report`)
+> 
+>    > <question-title></question-title>
+>    > 
+>    > 1. Wie viel % der Reads enthalten Adapter?
+>    > 2. Wie viel % der Reads wurden wegen schlechter Qualität abgeschnitten?
+>    > 3. Wie viel % der Reads wurden entfernt, weil sie zu kurz waren?
+>    > 
+>    > > <solution-title></solution-title>
+>    > > 1. 56,8% der Reads enthalten Adapter (`Reads with adapters:`)
+>    > > 2. 35,1% der Reads wurden wegen schlechter Qualität abgeschnitten (`Quality-trimmed:`)
+>    > > 3. 0 % der Reads wurden entfernt, weil sie zu kurz waren
+> > > 
+> > {: .solution }
+> > 
+> {: .question}
+> 
+{: .hands_on}
+
+
+> <details-title>Trimming mit Cutadapt</details-title>
+> 
+> Einer der größten Vorteile von Cutadapt im Vergleich zu anderen Trimming-Tools (z.B. TrimGalore!) ist, dass es eine gute [Dokumentation] (https://cutadapt.readthedocs.io) gibt, die die Funktionsweise des Tools im Detail erklärt.
+> 
+> Der Cutadapt-Algorithmus zum Trimmen der Qualität besteht aus drei einfachen Schritten:
+> 
+> 1. Subtrahieren Sie den gewählten Schwellenwert vom Qualitätswert jeder Position
+> 2. Berechnen Sie eine Teilsumme dieser Unterschiede vom Ende der Sequenz bis zu jeder Position (solange die Teilsumme negativ ist)
+> 3. Schnitt beim Minimalwert der Partialsumme
+> 
+> Im folgenden Beispiel gehen wir davon aus, dass das 3'-Ende mit einem Schwellenwert von 10 qualitätsgekürzt werden soll und wir folgende Qualitätswerte haben
+> 
+> ```
+> 42 40 26 27 8 7 11 4 2 3
+> ```
+> 
+> 1. Subtrahieren Sie den Schwellenwert
+> 
+>     ```
+>     32 30 16 17 -2 -3 1 -6 -8 -7
+>     ```
+> 
+> 2. Addieren Sie die Zahlen, beginnend am 3'-Ende (Teilsummen) und hören Sie frühzeitig auf, wenn die Summe größer als Null ist
+> 
+>     ```
+>     (70) (38) 8 -8 -25 -23 -20, -21 -15 -7
+>     ```
+> 
+>    Die Zahlen in Klammern sind nicht berechnet (weil 8 größer als Null ist), werden hier aber der Vollständigkeit halber gezeigt.
+> 
+> 3. Wählen Sie die Position des Minimums (`-25`) als Trimmposition
+> 
+> Daher wird der Read auf die ersten vier Basen beschnitten, die Qualitätswerte aufweisen
+> 
+> ```
+> 42 40 26 27
+> ```
+> 
+> Man beachte, dass daher auch Positionen mit einem Qualitätswert größer als der gewählte Schwellenwert entfernt werden, wenn sie in Regionen mit geringerer Qualität eingebettet sind (die Teilsumme ist abnehmend, wenn die Qualitätswerte kleiner als der Schwellenwert sind). Der Vorteil dieses Verfahrens ist, dass es robust gegenüber einer kleinen Anzahl von Positionen mit einer Qualität über dem Schwellenwert ist.
+> 
+> 
+> Alternativen zu diesem Verfahren wären:
+> 
+> * Schnitt nach der ersten Position mit einer Qualität kleiner als der Schwellenwert
+> * Schiebefenster-Ansatz
+> 
+>   Der Ansatz des gleitenden Fensters prüft, ob die durchschnittliche Qualität jedes Sequenzfensters einer bestimmten Länge größer als der Schwellenwert ist. Beachten Sie, dass dieser Ansatz im Gegensatz zu cutadapt einen weiteren Parameter hat und die Robustheit von der Länge des Fensters (in Kombination mit dem Qualitätsschwellenwert) abhängt. Beide Ansätze sind in Trimmomatic implementiert.
+> 
+{: .details}
+
+
+Wir können unsere beschnittenen Daten mit FASTQE und/oder FastQC untersuchen.
+
+> <hands-on-title>Überprüfung der Qualität nach dem Trimmen</hands-on-title>
+> 
+> 1. {% tool [FASTQE](toolshed.g2.bx.psu.edu/repos/iuc/fastqe/fastqe/0.3.1+galaxy0) %}: Führen Sie **FASTQE** mit den folgenden Parametern erneut aus
+>    - {% icon param-files %} *"FastQ-Daten "*: `Cutadapt Read 1 Output`
+>    - {% icon param-select %} *"Anzuzeigende Score-Typen "*: `Mean`
+> 
+> 2. Prüfen Sie den neuen FASTQE-Bericht
+> 
+>    > <question-title></question-title>
+>    > 
+>    > Vergleichen Sie die FASTQE-Ausgabe mit der vorherigen Ausgabe vor dem obigen Trimmen. Wurde die Sequenzqualität verbessert?
+>    > 
+>    > {% snippet faqs/galaxy/features_scratchbook.md %}
+>    > 
+>    > > <solution-title></solution-title> Ja, die Emojis für die Qualitätsbewertung sehen jetzt besser (fröhlicher) aus.
+>    > > 
+>    > > ![FASTQE before](../../images/quality-control/fastqe-mean-before.png "Before trimming")
+>    > > 
+>    > > ![FASTQE after](../../images/quality-control/fastqe-mean-after.png "After trimming")
+>    > > 
+> > > 
+> > {: .solution }
+> > 
+> {: .question}
+> 
+{: .hands_on}
+
+Mit FASTQE konnten wir die Qualität der Basen im Datensatz verbessern.
+
+Wir können auch, oder stattdessen, die qualitätskontrollierten Daten mit FastQC überprüfen.
+
+
+> <hands-on-title>Überprüfung der Qualität nach dem Trimmen</hands-on-title>
+> 
+> 1. {% tool [FASTQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0) %} mit den folgenden Parametern
+>    - {% icon param-files %} *"Kurze Lesedaten aus Ihrer aktuellen Historie "*: `Cutadapt Read 1 Output`
+> 
+> 2. Prüfen Sie die generierte HTML-Datei
+> 
+{: .hands_on}
+
+> <question-title></question-title>
+> 1. Sieht die Qualität der Sequenz pro Base besser aus?
+> 2. Ist der Adapter weg?
+> 
+> > <solution-title></solution-title>
+> > 1. Ja. Die überwiegende Mehrheit der Basen hat jetzt einen Qualitätswert von über 20. per base sequence quality](../../images/quality-control/per_base_sequence_quality-after.png "Per base sequence quality")
+> > 
+> > 2. Ja. Jetzt wird kein Adapter erkannt. ![Adapterinhalt](../../images/quality-control/adapter_content-after.png)
+> > 
+> {: .solution }
+> 
+{: .question}
+
+Mit FastQC konnten wir die Qualität der Basen im Datensatz verbessern und den Adapter entfernen.
+
+> <details-title>Andere FastQC-Plots nach dem Trimmen</details-title>
+> 
+> ![Per tile sequence quality](../../images/quality-control/per_tile_sequence_quality-after.png) Wir haben einige rote Streifen, da wir diese Regionen aus den Reads herausgeschnitten haben.
+> 
+> ![Per sequence quality scores](../../images/quality-control/per_sequence_quality_scores-after.png) Wir haben jetzt einen Peak hoher Qualität anstelle eines hohen und eines niedrigeren, wie wir ihn vorher hatten.
+> 
+> ![Per base sequence content](../../images/quality-control/per_base_sequence_content-after.png) Da es sich um Amplikon-Daten handelt, sind die Basen nicht mehr gleichmäßig vertreten.
+> 
+> ![GC-Gehalt pro Sequenz](../../images/quality-control/per_sequence_gc_content-after.png) Wir haben jetzt einen einzigen Haupt-GC-Peak aufgrund der Entfernung des Adapters.
+> 
+> ![Per base N content](../../images/quality-control/per_base_n_content-after.png) Dies ist dasselbe wie vorher, da wir keine Ns in diesen Reads haben.
+> 
+> ![Sequenzlängenverteilung](../../images/quality-control/sequence_length_distribution-after.png) Wir haben jetzt mehrere Peaks und eine Reihe von Längen, anstelle des einzelnen Peaks, den wir vor dem Trimmen hatten, als alle Sequenzen die gleiche Länge hatten.
+> 
+> ![Sequenzduplikationsstufen](../../images/quality-control/sequence_duplication_levels-after.png)
+> > <question-title></question-title>
+> > 
+> > Was entspricht der am stärksten überrepräsentierten Sequenz `GTGTCAGCCGCCGCGGTAGTCCGACGTGG`?
+> > 
+> > > <solution-title></solution-title> Wenn wir die am stärksten überrepräsentierte Sequenz nehmen
+> > > ```
+> > > >overrep_seq1_after
+> > > GTGTCAGCCGCCGCGGTAGTCCGACGTGG
+> > > ```
+> > > und [blastn](https://blast.ncbi.nlm.nih.gov/Blast.cgi) gegen die Standard-Nukleotiddatenbank (nr/nt) verwenden, sehen wir, dass die besten Treffer bei 16S rRNA-Genen zu finden sind. Dies ist sinnvoll, da es sich um 16S-Amplikon-Daten handelt, bei denen das 16S-Gen durch PCR amplifiziert wird.
+> > > 
+> > {: .solution }
+> > 
+> {: .question}
+> 
+{: .details}
+
+
+# Verarbeitung mehrerer Datensätze
+
+## Verarbeitung von Paired-End-Daten
+
+Bei der Paired-End-Sequenzierung werden die Fragmente von beiden Seiten sequenziert. Dieser Ansatz führt zu zwei Reads pro Fragment, wobei der erste Read in Vorwärtsorientierung und der zweite Read in Rückwärtskomplement-Orientierung erfolgt. Mit dieser Technik haben wir den Vorteil, dass wir mehr Informationen über jedes DNA-Fragment erhalten, als wenn wir nur mit Single-End-Sequenzierung sequenzieren:
+
+```
+    ------>                       [single-end]
+
+    ----------------------------- [fragment]
+
+    ------>               <------ [paired-end]
+```
+Der Abstand zwischen den beiden Reads ist bekannt und stellt daher eine zusätzliche Information dar, die die Zuordnung der Reads verbessern kann.
+
+Die Paired-End-Sequenzierung erzeugt 2 FASTQ-Dateien:
+- Eine Datei mit den Sequenzen, die der **vorwärts** Orientierung aller Fragmente entsprechen
+- Eine Datei mit den Sequenzen, die der **umgekehrten** Orientierung aller Fragmente entsprechen
+
+Normalerweise erkennen wir diese beiden Dateien, die zu einer Probe gehören, an dem Namen, der den gleichen Bezeichner für die Reads, aber eine unterschiedliche Erweiterung hat, z. B. `sampleA_R1.fastq` für die Forward Reads und `sampleA_R2.fastq` für die Reverse Reads. Es kann auch `_f` oder `_1` für die Forward Reads und `_r` oder `_2` für die Reverse Reads sein.
+
+Die Daten, die wir im vorigen Schritt analysiert haben, waren Single-End-Daten, so dass wir einen Paired-End-RNA-seq-Datensatz importieren werden. Wir werden FastQC ausführen und die beiden Berichte mit MultiQC {% cite ewels2016multiqc %} aggregieren.
+
+> <hands-on-title>Bewertung der Qualität von Paired-End-Reads</hands-on-title>
+> 
+> 1. Importieren Sie die Paired-End-Reads `GSM461178_untreat_paired_subset_1.fastq` und `GSM461178_untreat_paired_subset_2.fastq` von [Zenodo] (https://zenodo.org/record/61771) oder aus der Datenbibliothek (fragen Sie Ihren Lehrer)
+> 
+>    ```
+>    https://zenodo.org/record/61771/files/GSM461178_untreat_paired_subset_1.fastq
+>    https://zenodo.org/record/61771/files/GSM461178_untreat_paired_subset_2.fastq
+>    ```
+> 
+> 2. {% tool [FASTQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0) %} mit beiden Datensätzen:
+>    - {% icon param-files %} *"Raw read data from your current history "*: die beiden hochgeladenen Datensätze.
+> 
+>    {% snippet faqs/galaxy/tools_select_multiple_datasets.md %}
+> 
+> 3. {% tool [MultiQC](toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9+galaxy1) %} mit den folgenden Parametern, um die FastQC-Berichte von Vorwärts- und Rückwärts-Reads zu aggregieren
+>      - In *"Ergebnisse "*
+>        - *"Mit welchem Tool wurden die Protokolle erstellt? "*: `FastQC`
+>        - In *"FastQC output "*
+>           - *"Typ der FastQC-Ausgabe? "*: `Raw data`
+>           - {% icon param-files %} *"FastQC-Ausgabe "*: `Raw data`-Dateien (Ausgabe der beiden **FastQC** {% icon tool %})
+> 
+> 4. Prüfen Sie die Webpage-Ausgabe von MultiQC.
+> 
+{: .hands_on}
+
+
+> <question-title></question-title>
+> 
+> 1. Was halten Sie von der Qualität der Sequenzen?
+> 2. Was sollten wir tun?
+> 
+> > <solution-title></solution-title>
+> > 
+> > 1. Die Qualität der Sequenzen scheint bei den Reverse-Reads schlechter zu sein als bei den Forward-Reads:
+> >     - Per Sequence Quality Scores: Verteilung eher links, d. h. eine niedrigere mittlere Qualität der Sequenzen
+> >     - Qualität der Sequenz pro Base: weniger glatte Kurve und stärkerer Abfall am Ende mit einem Mittelwert unter 28
+> >     - Per Base Sequence Content: stärkere Verzerrung am Anfang und keine klare Unterscheidung zwischen C-G und A-T Gruppen
+> > 
+> >    Die anderen Indikatoren (Adapter, Duplikationsgrad, etc.) sind ähnlich.
+> > 
+> > 2. Wir sollten das Ende der Sequenzen abschneiden und sie mit **Cutadapt** {% icon tool %} filtern
+> > 
+> {: .solution}
+> 
+{: .question}
+
+Bei Paired-End-Reads sind die durchschnittlichen Qualitätswerte für Forward-Reads fast immer höher als für Reverse-Reads.
+
+Nach dem Trimmen sind die Reverse-Reads aufgrund ihrer Qualität kürzer und werden während des Filterungsschritts eliminiert. Wenn einer der Reverse-Reads entfernt wird, sollte auch der entsprechende Forward-Read entfernt werden. Andernfalls erhalten wir eine unterschiedliche Anzahl von Reads in beiden Dateien und in unterschiedlicher Reihenfolge, und die Reihenfolge ist für die nächsten Schritte wichtig. Daher **ist es wichtig, die Forward- und Reverse-Reads beim Trimmen und Filtern gemeinsam zu behandeln**.
+
+> <hands-on-title>Verbesserung der Qualität von Paired-End-Daten</hands-on-title>
+> 1. {% tool [Cutadapt](toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.9+galaxy1) %} mit den folgenden Parametern
+>    - *"Single-end or Paired-end reads? "*: `Paired-end`
+>       - {% icon param-file %} *"FASTQ/A-Datei #1"*: `GSM461178_untreat_paired_subset_1.fastq` (Eingabedatensatz)
+>       - {% icon param-file %} *"FASTQ/A-Datei #2"*: `GSM461178_untreat_paired_subset_2.fastq` (Eingabedatensatz)
+> 
+>         Die Reihenfolge ist hier wichtig!
+> 
+>       - In *Read 1 Adapters* oder *Read 2 Adapters*
+> 
+>         In diesen Datensätzen wurden keine Adapter gefunden. Wenn Sie Ihre eigenen Daten verarbeiten und wissen, welche Adaptersequenzen bei der Bibliotheksvorbereitung verwendet wurden, sollten Sie die Sequenzen hier angeben.
+> 
+>    - In *"Other Read Trimming Options "*
+>       - *"Quality cutoff(s) (R1) "*: `20`
+>    - In *"Read Filtering Options "*
+>       - *"Mindestlänge (R1) "*: `20`
+>    - {%icon param-select%} *"Zusätzliche zu erzeugende Ausgaben "*: `Report`
+> 
+> 2. Prüfen Sie die erzeugte txt-Datei (`Report`)
+> 
+>    > <question-title></question-title>
+>    > 
+>    > 1. Wie viele Basenpaare wurden aufgrund schlechter Qualität aus den Reads entfernt?
+>    > 2. Wie viele Sequenzpaare wurden entfernt, weil sie zu kurz waren?
+>    > 
+>    > > <solution-title></solution-title>
+>    > > 1. 44.164 bp (`Quality-trimmed:`) für die Forward Reads und 138.638 bp für die Reverse Reads.
+>    > > 2. 1.376 Sequenzen wurden entfernt, weil mindestens ein Read kürzer als der Längen-Cutoff war (322, wenn nur die Forward Reads analysiert wurden).
+> > > 
+> > {: .solution }
+> > 
+> {: .question}
+> 
+{: .hands_on}
+
+Zusätzlich zu dem Bericht erzeugt Cutadapt 2 Dateien:
+- Read 1 mit den getrimmten und gefilterten Forward Reads
+- Read 2 mit den beschnittenen und gefilterten Reverse Reads
+
+Diese Datensätze können für die nachgelagerte Analyse, z. B. für das Mapping, verwendet werden.
+
+> <question-title></question-title>
+> 
+> 1. Welche Art von Alignment wird für die Suche nach Adaptern in Reads verwendet?
+> 2. Welches ist das Kriterium für die Auswahl des besten Adapter-Alignments?
+> 
+> > <solution-title></solution-title>
+> > 
+> > 1. Semiglobales Alignment, d. h. nur der sich überlappende Teil der Lesung und der Adaptersequenz wird für die Auswertung verwendet.
+> > 2. Es wird ein Alignment mit maximaler Überlappung berechnet, das die geringste Anzahl von Mismatches und Indels aufweist.
+> > 
+> {: .solution}
+> 
+{: .question}
+
+# Bewertung der Qualität mit Nanoplot - nur lange Reads
+
+Bei langen Reads können wir die Sequenzqualität mit [Nanoplot](https://github.com/wdecoster/NanoPlot/) ({% cite 10.1093/bioinformatics/bty149 %}) überprüfen. Es bietet grundlegende Statistiken mit schönen Diagrammen für einen schnellen Überblick über die Qualitätskontrolle.
+
+> <hands-on-title>Qualitätsprüfung von langen Reads</hands-on-title>
+> 1. Erstellen Sie einen neuen Verlauf für diesen Teil und geben Sie ihm einen passenden Namen
+> 
+> 2. Importieren Sie die PacBio HiFi-Reads `m64011_190830_220126.Q20.subsample.fastq.gz` von [Zenodo](https://zenodo.org/record/5730295)
+> 
+>    ```
+>    https://zenodo.org/records/5730295/files/m64011_190830_220126.Q20.subsample.fastq.gz
+>    ```
+> 
+> 3. {% tool [Nanoplot](toolshed.g2.bx.psu.edu/repos/iuc/nanoplot/nanoplot/1.41.0+galaxy0) %} mit den folgenden Parametern
+>    - {% icon param-files %} *"files "*: `m64011_190830_220126.Q20.subsample.fastq.gz`
+>    - *"Optionen für die Anpassung der erstellten Diagramme "*
+>        - {% icon param-select %} *"Geben Sie das bivariate Format der Diagramme an. "*: `dot`, `kde`
+>        - {% icon param-select %} *"Zeigt die N50-Markierung im Leselängenhistogramm an. "*: `Yes`
+> 
+> 4. Prüfen Sie die generierte HTML-Datei
+> 
+{: .hands_on}
+
+> <question-title></question-title>
+> 
+> Was ist der mittlere Qscore?
+> 
+> > <solution-title></solution-title> Der Qscore liegt bei Q32. Im Falle von PacBio CLR und Nanopore liegt er bei Q12 und bei Illumina (NovaSeq 6000) nahe bei Q31. plot of Qscore between Illumina, PacBio and Nanopore](../../images/quality-control/qscore-illumina-pacbio-nanopore.png "Comparison of Qscore between Illumina, PacBio and Nanopore")
+> > 
+> > Definition: Qscores ist die durchschnittliche Fehlerwahrscheinlichkeit pro Base, ausgedrückt auf der log (Phred)-Skala
+> > 
+> {: .solution }
+> 
+> Was ist der Median, Mittelwert und N50?
+> > <solution-title></solution-title> Der Median, die mittlere Leselänge und auch N50 liegen nahe bei 18.000bp. Bei PacBio HiFi-Reads liegt die Mehrheit der Reads im Allgemeinen in der Nähe dieses Wertes, da die Bibliotheksvorbereitung einen Schritt zur Größenauswahl umfasst. Bei anderen Technologien wie PacBio CLR und Nanopore ist der Wert größer und hängt hauptsächlich von der Qualität Ihrer DNA-Extraktion ab.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+## Histogramm der Leselängen
+
+Diese Grafik zeigt die Verteilung der Fragmentgrößen in der analysierten Datei. Im Gegensatz zu den meisten Illumina-Läufen haben lange Reads eine variable Länge, und dies zeigt die relativen Mengen der einzelnen Sequenzfragmente unterschiedlicher Größe. In diesem Beispiel ist die Verteilung der Leselänge in der Nähe von 18kbp zentriert, aber die Ergebnisse können je nach Experiment sehr unterschiedlich sein.
+
+![Histogramm der Leselängen](../../images/quality-control/HistogramReadlength.png "Histogramm der Leselänge")
+
+## Darstellung der Leselängen im Vergleich zur durchschnittlichen Lesequalität mit Punkten
+
+Diese Darstellung zeigt die Verteilung der Fragmentgrößen entsprechend dem Qscore in der analysierten Datei. Im Allgemeinen gibt es keinen Zusammenhang zwischen Leselänge und Lesequalität, aber diese Darstellung ermöglicht es, beide Informationen in einem einzigen Diagramm zu visualisieren und mögliche Abweichungen zu erkennen. In Läufen mit vielen kurzen Reads sind die kürzeren Reads manchmal von geringerer Qualität als der Rest.
+
+![Leselängen vs. durchschnittliche Lesequalität mittels Punkten](../../images/quality-control/LengthvsQualityScatterPlot_dot.png "Histogram of read length")
+
+> <question-title></question-title> Betrachten Sie "Read lengths vs Average read quality plot using dots plot". Ist Ihnen beim Qscore etwas Ungewöhnliches aufgefallen? Können Sie das erklären?
+> > <solution-title></solution-title> Es gibt keine Reads unter Q20. Die Qualifikation für HiFi-Reads lautet:
+> > - Eine minimale Anzahl von 3 Subreads
+> > - A read Qscore >=20 ![PacBio HiFi sequencing](../../images/quality-control/pacbio-css-hifi-sequencing.png "PacBio HiFi sequencing")
+> > 
+> {: .solution }
+> 
+{: .question}
+
+> <comment-title>Try it on!</comment-title> Führen Sie die Qualitätskontrolle mit **FastQC** {% icon tool %} auf `m64011_190830_220126.Q20.subsample.fastq.gz` durch und vergleichen Sie die Ergebnisse!
+> 
+{: .comment}
+
+# Bewertung der Qualität mit PycoQC - nur Nanopore
+
+[PycoQC](https://github.com/tleonardi/pycoQC) ({% cite Leger2019 %}) ist ein Datenvisualisierungs- und Qualitätskontrollwerkzeug für Nanopore-Daten. Im Gegensatz zu FastQC/Nanoplot benötigt es eine spezifische sequencing_summary.txt Datei, die von Oxford Nanopore Basecallern wie Guppy oder dem älteren Albacore Basecaller generiert wird.
+
+Eine der Stärken von PycoQC ist, dass es interaktiv und in hohem Maße anpassbar ist, z. B. können Plots beschnitten werden, man kann hinein- und herauszoomen, Bereiche unterwählen und Zahlen exportieren.
+
+> <hands-on-title>Qualitätsprüfung von Nanopore-Reads</hands-on-title>
+> 1. Erstellen Sie einen neuen Verlauf für diesen Teil und geben Sie ihm einen passenden Namen
+> 
+> 2. Import der Nanopore-Reads `nanopore_basecalled-guppy.fastq.gz` und `sequencing_summary.txt` von [Zenodo](https://zenodo.org/record/5730295)
+> 
+>    ```
+>    https://zenodo.org/records/5730295/files/nanopore_basecalled-guppy.fastq.gz
+>    https://zenodo.org/records/5730295/files/sequencing_summary.txt
+>    ```
+> 
+> 3. {% tool [PycoQC](toolshed.g2.bx.psu.edu/repos/iuc/pycoqc/pycoqc/2.5.2+galaxy0) %} mit den folgenden Parametern
+> 
+>    - {% icon param-files %} *"Eine Sequenzierungs_Zusammenfassungsdatei "*: `sequencing_summary.txt`
+> 
+> 4. Prüfen Sie die Webpage-Ausgabe von PycoQC
+> 
+{: .hands_on}
+
+> <question-title></question-title>
+> 
+> Wie viele Reads haben Sie insgesamt?
+> > <solution-title></solution-title> ~270k Reads insgesamt (siehe Basecall-Zusammenfassungstabelle "Alle Reads") Bei den meisten Basecalling-Profilen stuft Guppy die Reads als "Pass" ein, wenn der Qscore der Reads mindestens gleich 7 ist.
+> > 
+> {: .solution }
+> 
+> Was ist der Median, das Minimum und das Maximum der Leselänge, was ist der N50?
+> > <solution-title></solution-title> Die mediane Leselänge und der N50-Wert können für alle sowie für alle bestandenen Reads, d. h. für Reads, die die Guppy-Qualitätseinstellungen (Qscore >= 7) bestanden haben, in der Basecall-Zusammenfassungstabelle gefunden werden. Für die minimale (195bp) und maximale (256kbp) Leselänge kann sie mit dem Leselängenplot ermittelt werden.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+## Länge der basisabgerufenen Reads
+
+Wie bei FastQC und Nanoplot zeigt diese Darstellung die Verteilung der Fragmentgrößen in der analysierten Datei. Wie bei PacBio CLR/HiFi haben lange Reads eine variable Länge, und dies zeigt die relativen Mengen der einzelnen Sequenzfragmente unterschiedlicher Größe. In diesem Beispiel ist die Verteilung der Leselänge recht breit gestreut mit einer minimalen Leselänge für die übergebenen Reads um 200bp und einer maximalen Länge von ~150.000bp.
+
+![Basecalled reads length](../../images/quality-control/basecalled_reads_length-pycoqc.png "Basecalled reads length")
+
+### Basecalled reads PHRED quality
+
+Diese Grafik zeigt die Verteilung der Q-Scores (Q) für jeden Read. Dieser Wert soll eine globale Qualitätsbewertung für jeden Read liefern. Die genaue Definition von Qscores ist: die durchschnittliche Fehlerwahrscheinlichkeit pro Base, ausgedrückt auf der log (Phred) Skala. Bei Nanopore-Daten liegt die Verteilung in der Regel um 10 oder 12 herum. Bei alten Läufen kann die Verteilung niedriger sein, da die Basecalling-Modelle weniger genau sind als neuere Modelle.
+
+![Basecalled reads PHRED quality](../../images/quality-control/basecalled_reads_PHRED_quality-pycoqc.png "Basecalled reads PHRED quality")
+
+## Länge der Basecalled Reads vs. Reads PHRED-Qualität
+
+> <question-title></question-title> Wie sehen die mittlere Qualität und die Qualitätsverteilung des Laufs aus?
+> > <solution-title></solution-title> Die Mehrheit der Reads hat einen Qscore zwischen 8 und 11, was für Nanopore-Daten Standard ist. Beachten Sie, dass für dieselben Daten der verwendete Basecaller (Albacor, Guppy, Bonito), das Modell (fast, hac, sup) und die Toolversion unterschiedliche Ergebnisse liefern können.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+Wie bei NanoPlot bietet diese Darstellung eine 2D-Visualisierung des Read-QScores in Abhängigkeit von der Länge.
+
+![Basecalled reads length vs reads PHRED quality](../../images/quality-control/basecalled_reads_length_vs_reads_PHRED_quality-pycoqc.png "Basecalled reads length vs reads PHRED quality")
+
+## Ausgabe über die Experimentierzeit
+
+Diese Darstellung gibt Auskunft über die sequenzierten Reads über die Zeit für einen einzelnen Lauf:
+
+- Jedes Bild zeigt eine neue Ladung der Fließzelle an (3 + die erste Ladung).
+- Der Anteil an den gesamten Reads für jedes "Tanken".
+- Die Produktion von Reads nimmt mit der Zeit ab:
+  - Der größte Teil des Materials (DNA/RNA) ist sequenziert
+  - Sättigung der Poren
+  - Material-/Porendegradation
+  - ...
+
+In diesem Beispiel ist der Beitrag jeder Betankung sehr gering, und es kann als schlechter Lauf betrachtet werden. Der "Cummulative"-Plotbereich (hellblau) zeigt an, dass 50 % aller Reads und fast 50 % aller Basen in den ersten 5 Stunden des 25-Stunden-Experiments produziert wurden. Obwohl es normal ist, dass die Ausbeute mit der Zeit abnimmt, ist ein derartiger Rückgang kein gutes Zeichen.
+
+![Ausgabe über die Experimentierzeit](../../images/quality-control/output_over_experiment_time-pycoqc.png "Ausgabe über die Experimentierzeit")
+
+> <details-title>Sonstiges Profil "Output über die Experimentierzeit"</details-title>
+> 
+> In diesem Beispiel nahm die Datenproduktion im Laufe der 12 Stunden nur geringfügig ab, während die kumulativen Daten kontinuierlich zunahmen. Das Fehlen einer abfallenden Kurve am Ende des Laufs deutet darauf hin, dass sich noch biologisches Material auf der Fließzelle befindet. Der Lauf wurde beendet, bevor alles sequenziert war. Es ist ein ausgezeichneter Lauf, der sogar als außergewöhnlich bezeichnet werden kann.
+> 
+> ![Output über Experimentierzeit gutes Profil](../../images/quality-control/output_over_experiment_time-pycoqc-good.png)
+> 
+{: .details}
+
+### Leselänge über die Experimentierzeit
+
+> <question-title></question-title> Hat sich die Leselänge im Laufe der Zeit verändert? Was könnte der Grund dafür sein?
+> > <solution-title></solution-title> Im vorliegenden Beispiel nimmt die Leselänge mit der Zeit des Sequenzierungslaufs zu. Eine Erklärung dafür ist, dass die Adapterdichte bei vielen kurzen Fragmenten höher ist und daher die Chance, dass sich ein kürzeres Fragment an eine Pore anlagert, größer ist. Außerdem bewegen sich kürzere Moleküle möglicherweise schneller über den Chip. Mit der Zeit werden die kürzeren Fragmente jedoch seltener, so dass mehr lange Fragmente an den Poren haften und sequenziert werden.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+Die Leselänge über die Experimentierzeit sollte stabil sein. Sie kann im Laufe der Zeit leicht ansteigen, da kurze Fragmente zu Beginn übersequenziert werden und im Laufe der Zeit weniger vorhanden sind.
+
+![Read length over experiment time](../../images/quality-control/read_length_over_experiment_time-pycoqc.png "Read length over experiment time")
+
+## Kanalaktivität im Zeitverlauf
+
+Es gibt einen Überblick über die verfügbaren Poren, die Porenauslastung während des Experiments, die inaktiven Poren und zeigt, ob die Fließzelle gut ausgelastet ist (fast alle Poren werden genutzt). In diesem Fall ist die große Mehrheit der Kanäle/Poren während des gesamten Sequenzierungslaufs inaktiv (weiß), so dass der Lauf als schlecht eingestuft werden kann.
+
+Man hofft auf eine Darstellung, die in der Nähe der X-Achse dunkel ist und bei höheren Y-Werten (mit zunehmender Zeit) nicht zu hell/weiß wird. Je nachdem, ob Sie links "Reads" oder "Basen" auswählen, zeigt die Farbe entweder die Anzahl der Basen oder der Reads pro Zeitintervall an
+
+![Kanalaktivität im Zeitverlauf](../../images/quality-control/channel_activity_over_time-pycoqc.png "Kanalaktivität im Zeitverlauf")
+
+> <details-title>Sonstiges Profil "Kanalaktivität über die Zeit"</details-title>
+> 
+> In diesem Beispiel sind fast alle Poren während des gesamten Laufs aktiv (gelbes/rotes Profil), was auf einen ausgezeichneten Lauf hinweist.
+> 
+> ![Profil Kanalaktivität über die Zeit gut](../../images/quality-control/channel_activity_over_time-pycoqc-good.png)
+> 
+{: .details}
+
+
+> <comment-title>Try it out!</comment-title> Führen Sie die Qualitätskontrolle mit **FastQC** {% icon tool %} und/oder **Nanoplot** {% icon tool %} auf `nanopore_basecalled-guppy.fastq.gz` durch und vergleichen Sie die Ergebnisse!
+> 
+{: .comment}
+
+# Schlussfolgerung
+
+
+In diesem Lernprogramm haben wir die Qualität der FASTQ-Dateien überprüft, um sicherzustellen, dass die Daten gut aussehen, bevor wir weitere Informationen ableiten. Dieser Schritt ist der übliche erste Schritt für Analysen wie RNA-Seq, ChIP-Seq oder andere OMIC-Analysen, die auf NGS-Daten beruhen. Die Schritte der Qualitätskontrolle sind für jede Art von Sequenzierungsdaten ähnlich:
+
+- Qualitätsbewertung mit Tools wie:
+  - *Short Reads*: {% tool [FASTQE](toolshed.g2.bx.psu.edu/repos/iuc/fastqe/fastqe/0.3.1+galaxy0) %}
+  - *Kurz+Lang*: {% tool [FASTQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0) %}
+  - *Long Reads*: {% tool [Nanoplot](toolshed.g2.bx.psu.edu/repos/iuc/nanoplot/nanoplot/1.41.0+galaxy0) %}
+  - *Nur Nanopore*: {% tool [PycoQC](toolshed.g2.bx.psu.edu/repos/iuc/pycoqc/pycoqc/2.5.2+galaxy0) %}
+- Trimmen und Filtern nach **kurzen Reads** mit einem Tool wie **Cutadapt** {% icon tool %}
+

--- a/topics/sequence-analysis/tutorials/quality-control/es/tutorial.md
+++ b/topics/sequence-analysis/tutorials/quality-control/es/tutorial.md
@@ -1,0 +1,1112 @@
+---
+layout: tutorial_hands_on
+title: Control de calidad
+zenodo_link: https://zenodo.org/records/61771
+questions:
+- How to perform quality control of NGS raw data?
+- What are the quality parameters to check for a dataset?
+- How to improve the quality of a dataset?
+objectives:
+- Assess short reads FASTQ quality using FASTQE 🧬😎 and FastQC
+- Assess long reads FASTQ quality using Nanoplot and PycoQC
+- Perform quality correction with Cutadapt (short reads)
+- Summarise quality metrics MultiQC
+- Process single-end and paired-end data
+follow_up_training:
+- type: internal
+  topic_name: sequence-analysis
+  tutorials:
+  - mapping
+time_estimation: 1H30M
+level: Introductory
+subtopic: basics
+key_points:
+- Perform quality control on every dataset before running any other bioinformatics
+  analysis
+- Assess the quality metrics and improve quality if necessary
+- Check the impact of the quality control
+- Different tools are available to provide additional quality metrics
+- For paired-end reads analyze the forward and reverse reads together
+contributions:
+  authorship:
+  - bebatut
+  - mblue9
+  - alexcorm
+  - abretaud
+  - lleroi
+  - r1corre
+  - stephanierobin
+  - neoformit
+  editing:
+  - Swathi266
+  funding:
+  - gallantries
+recordings:
+- youtube_id: coaMGvZazoc
+  length: 50M
+  speakers:
+  - LonsBio
+  captioners:
+  - LonsBio
+  date: '2023-05-19'
+- captioners:
+  - bebatut
+  - nagoue
+  - shiltemann
+  date: '2021-02-15'
+  galaxy_version: '21.01'
+  length: 1H10M
+  youtube_id: QJRlX2hWDKM
+  speakers:
+  - heylf
+- youtube_id: uiWZea53QIA
+  length: 51M
+  galaxy_version: 24.1.2.dev0
+  date: '2024-09-30'
+  speakers:
+  - dianichj
+  captioners:
+  - dianichj
+  bot-timestamp: 1727710795
+---
+
+
+
+
+Durante la secuenciación, el secuenciador determina las bases nucleotídicas de una muestra de ADN o ARN (biblioteca). Para cada fragmento de la biblioteca se genera una secuencia, también llamada **lectura**, que no es más que una sucesión de nucleótidos.
+
+Las tecnologías modernas de secuenciación pueden generar un gran número de lecturas de secuencias en un solo experimento. Sin embargo, ninguna tecnología de secuenciación es perfecta, y cada instrumento generará diferentes tipos y cantidad de errores, como la llamada incorrecta de nucleótidos. Estas bases mal llamadas se deben a las limitaciones técnicas de cada plataforma de secuenciación.
+
+Por lo tanto, es necesario comprender, identificar y excluir los tipos de error que pueden afectar a la interpretación de los análisis posteriores. El control de calidad de la secuencia es, por tanto, un primer paso esencial en su análisis. Detectar los errores a tiempo ahorra tiempo más adelante.
+
+> <agenda-title></agenda-title>
+> 
+> En este tutorial, nos ocuparemos de:
+> 
+> 1. TOC {:toc}
+> 
+{: .agenda}
+
+# Inspeccionar un archivo de secuencia sin procesar
+
+> <hands-on-title>Carga de datos</hands-on-title>
+> 
+> 1. Crea un nuevo historial para este tutorial y dale un nombre apropiado
+> 
+>    {% snippet faqs/galaxy/histories_create_new.md %}
+> 
+>    {% snippet faqs/galaxy/histories_rename.md %}
+> 
+> 2. Importe el archivo `female_oral2.fastq-4143.gz` de [Zenodo](https://zenodo.org/record/3977236) o de la biblioteca de datos (pregunte a su instructor) Esta es una muestra de microbioma de una serpiente {% cite StJacques2021 %}.
+> 
+>    ```
+>    https://zenodo.org/record/3977236/files/female_oral2.fastq-4143.gz
+>    ```
+> 
+>    {% snippet faqs/galaxy/datasets_import_via_link.md %}
+> 
+>    {% snippet faqs/galaxy/datasets_import_from_data_library.md %}
+> 
+> 3. Cambie el nombre del conjunto de datos importado a `Reads`.
+> 
+{: .hands_on}
+
+Acabamos de importar un archivo a Galaxy. Este archivo es similar a los datos que podríamos obtener directamente de una instalación de secuenciación: un [archivo FASTQ](https://en.wikipedia.org/wiki/FASTQ_format).
+
+> <hands-on-title>Inspeccione el archivo FASTQ</hands-on-title>
+> 
+> 1. Inspeccione el archivo haciendo clic en el {% icono galaxy-eye %} (ojo)
+> 
+{: .hands_on}
+
+Aunque parece complicado (y puede que lo sea), el formato FASTQ es fácil de entender con un poco de decodificación.
+
+Cada lectura, que representa un fragmento de la biblioteca, está codificada por 4 líneas:
+
+| Line | Description                                                                                                                                                        |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1    | Always begins with `@` followed by the information about the read                                                                                                  |
+| 2    | The actual nucleic sequence                                                                                                                                        |
+| 3    | Always begins with a `+` and contains sometimes the same info in line 1                                                                                            |
+| 4    | Has a string of characters which represent the quality scores associated with each base of the nucleic sequence; must have the same number of characters as line 2 |
+
+Así, por ejemplo, la primera secuencia en nuestro archivo es:
+
+```
+@M00970:337:000000000-BR5KF:1:1102:17745:1557 1:N:0:CGCAGAAC+ACAGAGTT
+GTGCCAGCCGCCGCGGTAGTCCGACGTGGCTGTCTCTTATACACATCTCCGAGCCCACGAGACCGAAGAACATCTCGTATGCCGTCTTCTGCTTGAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAGAAGCAAATGACGATTCAAGAAAGAAAAAAACACAGAATACTAACAATAAGTCATAAACATCATCAACATAAAAAAGGAAATACACTTACAACACATATCAATATCTAAAATAAATGATCAGCACACAACATGACGATTACCACACATGTGTACTACAAGTCAACTA
++
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGFGGGFGGGGGGAFFGGFGGGGGGGGFGGGGGGGGGGGGGGFGGG+38+35*311*6,,31=******441+++0+0++0+*1*2++2++0*+*2*02*/***1*+++0+0++38++00++++++++++0+0+2++*+*+*+*+*****+0**+0**+***+)*.***1**//*)***)/)*)))*)))*),)0(((-((((-.(4(,,))).,(())))))).)))))))-))-(
+```
+
+Significa que el fragmento llamado `@M00970` corresponde a la secuencia de ADN `GTGCCAGCCGCCGCGGTAGTCCGACGTGGCTGTCTCTTATACACATCTCCGAGCCCACGAGACCGAAGAACATCTCGTATGCCGTCTTCTGCTTGAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAGAAGCAAATGACGATTCAAGAAAGAAAAAAACACAGAATACTAACAATAAGTCATAAACATCATCAACATAAAAAAGGAAATACACTTACAACACATATCAATATCTAAAATAAATGATCAGCACACAACATGACGATTACCACACATGTGTACTACAAGTCAACTA` y esta secuencia ha sido secuenciada con una calidad `GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGFGGGFGGGGGGAFFGGFGGGGGGGGFGGGGGGGGGGGGGGFGGG+38+35*311*6,,31=******441+++0+0++0+*1*2++2++0*+*2*02*/***1*+++0+0++38++00++++++++++0+0+2++*+*+*+*+*****+0**+0**+***+)*.***1**//*)***)/)*)))*)))*),)0(((-((((-.(4(,,))).,(())))))).)))))))-))-(`.
+
+{% snippet topics/sequence-analysis/faqs/quality_score.md %}
+
+> <question-title></question-title>
+> 
+> 1. ¿Qué carácter ASCII corresponde a la peor puntuación Phred para Illumina 1.8+?
+> 2. ¿Cuál es la puntuación de calidad Phred del 3er nucleótido de la 1ª secuencia?
+> 3. ¿Cómo calcular la precisión de la base de nucleótidos con el código ASCII `/`?
+> 4. ¿Cuál es la precisión de este 3er nucleótido?
+> 
+> > <solution-title></solution-title>
+> > 1. La peor puntuación Phred es la más pequeña, por lo tanto 0. Para Illumina 1.8+, corresponde al carácter `!`.
+> > 2. El 3er nucleótido de la 1ª secuencia tiene un carácter ASCII `G`, que corresponde a una puntuación de 38.
+> > 3. Se puede calcular de la siguiente manera:
+> >    - El código ASCII para `/` es 47
+> >    - Puntuación de calidad = 47-33=14
+> >    - Fórmula para hallar la probabilidad de error: \\(P = 10^-Q/10})
+> >    - Probabilidad de error = \\(10^{-14/10}\\\) = 0.03981
+> >    - Por lo tanto Exactitud = 100 - 0.03981 = 99.96%
+> > 4. El nucleótido correspondiente `G` tiene una precisión de casi el 99,96%
+> > 
+> {: .solution }
+> 
+{: .question}
+
+> <comment-title></comment-title> El lllumina actual (1.8+) utiliza el formato Sanger (Phred+33). Si está trabajando con conjuntos de datos más antiguos puede encontrarse con los esquemas de puntuación más antiguos. **FastQC** {% icon tool %}, una herramienta que utilizaremos más adelante en este tutorial, se puede utilizar para tratar de determinar qué tipo de codificación de calidad se utiliza (a través de la evaluación de la gama de valores Phred visto en el FASTQ).
+> 
+{: .comment}
+
+Al mirar el archivo en Galaxy, parece que la mayoría de los nucleótidos tienen una puntuación alta (`G` correspondiente a una puntuación 38). ¿Es esto cierto para todas las secuencias? ¿Y a lo largo de toda la secuencia?
+
+
+# Evaluar la calidad con FASTQE 🧬😎 - sólo lecturas cortas
+
+Para echar un vistazo a la calidad de la secuencia a lo largo de todas las secuencias, podemos utilizar [FASTQE](https://fastqe.com/). Es una herramienta de código abierto que proporciona una forma sencilla y divertida de controlar la calidad de los datos de secuencias en bruto e imprimirlos como emoji. Puede utilizarla para hacerse una idea rápida de si sus datos presentan algún problema del que deba ser consciente antes de realizar cualquier otro análisis.
+
+> <hands-on-title>Comprobación de calidad</hands-on-title>
+> 
+> 1. {% tool [FASTQE](toolshed.g2.bx.psu.edu/repos/iuc/fastqe/fastqe/0.3.1+galaxy0) %} con los siguientes parámetros
+>    - {% icon param-files %} *"FastQ data "*: `Reads`
+>    - {% icon param-select %} *"Tipos de puntuación a mostrar "*: `Mean`
+> 
+> 2. Inspeccione el archivo HTML generado
+> 
+{: .hands_on}
+
+En lugar de analizar las puntuaciones de calidad de cada lectura individual, FASTQE analiza la calidad de forma colectiva en todas las lecturas de una muestra y puede calcular la media de cada posición de nucleótido a lo largo de la longitud de las lecturas. A continuación se muestran los valores medios de este conjunto de datos.
+
+![FASTQE before](../../images/quality-control/fastqe-mean-before.png "Puntuaciones medias de FASTQE")
+
+Puede ver la puntuación de cada [emoji en la documentación de fastqe](https://github.com/fastqe/fastqe#scale). Los emojis de abajo, con puntuaciones Phred inferiores a 20, son los que esperamos no ver mucho.
+
+| Phred Quality Score | ASCII code | Emoji |
+| ------------------- | ---------- | ----- |
+| 0                   | !          | 🚫     |
+| 1                   | "          | ❌     |
+| 2                   | #          | 👺     |
+| 3                   | $          | 💔     |
+| 4                   | %          | 🙅     |
+| 5                   | &          | 👾     |
+| 6                   | '          | 👿     |
+| 7                   | (          | 💀     |
+| 8                   | )          | 👻     |
+| 9                   | *          | 🙈     |
+| 10                  | +          | 🙉     |
+| 11                  | ,          | 🙊     |
+| 12                  | -          | 🐵     |
+| 13                  | .          | 😿     |
+| 14                  | /          | 😾     |
+| 15                  | 0          | 🙀     |
+| 16                  | 1          | 💣     |
+| 17                  | 2          | 🔥     |
+| 18                  | 3          | 😡     |
+| 19                  | 4          | 💩     |
+
+
+> <question-title></question-title>
+> 
+> ¿Cuál es la puntuación media más baja en este conjunto de datos?
+> 
+> > <solution-title></solution-title> La puntuación más baja en este conjunto de datos es 😿 13.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+
+# Evaluar la calidad con FastQC - lecturas cortas y largas
+
+Una forma adicional o alternativa de comprobar la calidad de la secuencia es con [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/). Proporciona un conjunto modular de análisis que podemos utilizar para comprobar si nuestros datos tienen algún problema del que debamos ser conscientes antes de realizar cualquier otro análisis. Podemos utilizarlo, por ejemplo, para evaluar si hay adaptadores conocidos presentes en los datos. Lo ejecutaremos en el archivo FASTQ
+
+> <hands-on-title>Comprobación de calidad</hands-on-title>
+> 
+> 1. {% tool [FASTQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0) %} con los siguientes parámetros
+>    - {% icon param-files %} *"Datos de lectura crudos de su historia actual "*: `Reads`
+> 
+> 2. Inspeccione el archivo HTML generado
+> 
+{: .hands_on}
+
+> <question-title></question-title>
+> 
+> ¿Qué codificación Phred se utiliza en el archivo FASTQ para estas secuencias?
+> 
+> > <solution-title></solution-title> Las puntuaciones Phred se codifican utilizando `Sanger / Illumina 1.9` (`Encoding` en la tabla superior).
+> > 
+> {: .solution }
+> 
+{: .question}
+
+## Calidad de la secuencia por base
+
+Con FastQC podemos utilizar el gráfico de calidad de secuencia por base para comprobar la calidad de base de las lecturas, de forma similar a lo que hicimos con FASTQE.
+
+![Calidad de la secuencia por base](../../images/quality-control/per_base_sequence_quality-before.png "Calidad de la secuencia por base")
+
+En el eje x se muestra la posición de la base en la lectura. En este ejemplo, la muestra contiene lecturas de hasta 296 pb de longitud.
+
+> <details-title>Eje x no uniforme</details-title>
+> 
+> El eje x no siempre es uniforme. Cuando se tienen lecturas largas, se aplica cierto binning para mantener las cosas compactas. Podemos verlo en nuestra muestra. Comienza con 1-10 bases individuales. Después, las bases se agrupan en una ventana de un cierto número de bases de ancho. Agrupar datos significa agrupar y es una técnica de preprocesamiento de datos utilizada para reducir los efectos de pequeños errores de observación. El número de posiciones de bases agrupadas depende de la longitud de la lectura. Con lecturas de más de 50 pb, la última parte del gráfico mostrará estadísticas agregadas para ventanas de 5 pb. Las lecturas más cortas tendrán ventanas más pequeñas y las más largas ventanas más grandes. El agrupamiento puede eliminarse al ejecutar FastQC estableciendo el parámetro "Disable grouping of bases for reads >50bp" en Yes.
+> 
+{: .details}
+
+Para cada posición, se dibuja un boxplot con:
+
+- el valor mediano, representado por la línea roja central
+- el rango intercuartílico (25-75%), representado por el recuadro amarillo
+- los valores 10% y 90% en los bigotes superior e inferior
+- la calidad media, representada por la línea azul
+
+El eje y muestra las puntuaciones de calidad. Cuanto más alta es la puntuación, mejor es la llamada de la base. El fondo del gráfico divide el eje y en puntuaciones de muy buena calidad (verde), puntuaciones de calidad razonable (naranja) y lecturas de mala calidad (rojo).
+
+Es normal en todos los secuenciadores Illumina que la mediana de la puntuación de calidad comience siendo más baja en las primeras 5-7 bases y luego aumente. La calidad de las lecturas en la mayoría de las plataformas disminuirá al final de la lectura. Esto se debe a menudo a la decadencia de la señal o al desfase durante el proceso de secuenciación. Los recientes avances en la química aplicada a la secuenciación han mejorado algo este aspecto, pero las lecturas son ahora más largas que nunca.
+
+
+> <details-title>Deterioro de la señal y desfase</details-title>
+> 
+> - Decaimiento de la señal
+> 
+> La intensidad de la señal fluorescente decae con cada ciclo del proceso de secuenciación. Debido a la degradación de los fluoróforos, una proporción de las hebras del cluster no se está elongando. La proporción de la señal que se emite sigue disminuyendo con cada ciclo, lo que produce una disminución de las puntuaciones de calidad en el extremo 3' de la lectura.
+> 
+> - Fases
+> 
+> La señal empieza a difuminarse con el aumento del número de ciclos porque el cluster pierde sincronicidad. A medida que avanzan los ciclos, en algunas hebras se producen fallos aleatorios de nucleótidos a incorporar debido a:
+> 
+>  - Eliminación incompleta de los terminadores 3' y fluoróforos
+>  - Incorporación de nucleótidos sin terminadores 3' efectivos
+> 
+> Esto conduce a una disminución de las puntuaciones de calidad en el extremo 3' de la lectura.
+> 
+{: .details}
+
+
+> <details-title>Otros perfiles de calidad de secuencia</details-title>
+> 
+> Estos son algunos perfiles de calidad de secuencias por base que pueden indicar problemas con la secuenciación.
+> 
+> - Sobreagrupamiento
+> 
+>   Las instalaciones de secuenciación pueden agrupar en exceso las celdas de flujo. El resultado son pequeñas distancias entre los clusters y un solapamiento de las señales. Dos clusters pueden interpretarse como un único cluster, detectándose señales fluorescentes mezcladas, lo que disminuye la pureza de la señal. Genera puntuaciones de calidad más bajas en toda la lectura.
+> 
+> - Desglose de la instrumentación
+> 
+>   Ocasionalmente pueden producirse algunos problemas con los instrumentos de secuenciación durante un experimento. Cualquier caída repentina en la calidad o un gran porcentaje de lecturas de baja calidad a lo largo de la lectura podría indicar un problema en la instalación. Algunos ejemplos de estos problemas:
+> 
+>    - Ráfaga múltiple
+> 
+>      ![Manifold burst](../../images/quality-control/per_base_sequence_quality_manifold_burst.png)
+> 
+>    - Pérdida de ciclos
+> 
+>      ![Pérdida de ciclos](../../images/quality-control/per_base_sequence_quality_cycle_loss.png)
+> 
+>    - Fallo de lectura 2
+> 
+>      ![Cycles loss](../../images/quality-control/per_base_sequence_quality_read2_failure.png)
+> 
+>   Con estos datos, debe ponerse en contacto con el centro de secuenciación. A menudo, es necesaria una resecuenciación (que, según nuestra experiencia, también ofrece la empresa).
+> 
+{: .details}
+
+> <question-title></question-title>
+> 
+> 1. ¿Cómo cambia la puntuación media de calidad a lo largo de la secuencia?
+> 2. ¿Se observa esta tendencia en todas las secuencias?
+> 
+> > <solution-title></solution-title>
+> > 1. La puntuación media de calidad (línea azul) desciende aproximadamente a mitad de estas secuencias. Es habitual que la calidad media descienda hacia el final de las secuencias, ya que los secuenciadores incorporan más nucleótidos incorrectos al final. Sin embargo, en esta muestra se observa un descenso muy acusado de la calidad a partir de la mitad.
+> > 2. Los gráficos de caja son cada vez más amplios a partir de la posición ~100. Significa que la puntuación de muchas secuencias cae desde la mitad de la secuencia. Después de 100 nucleótidos, más del 10% de las secuencias tienen puntuaciones por debajo de 20.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+Cuando la mediana de calidad está por debajo de una puntuación Phred de ~20, deberíamos considerar la posibilidad de recortar las bases de mala calidad de la secuencia. Explicaremos este proceso en la sección Recortar y filtrar.
+
+### Contenido del adaptador
+
+![Contenido del adaptador](../../images/quality-control/adapter_content-before.png "Contenido del adaptador")
+
+El gráfico muestra el porcentaje acumulado de lecturas con las diferentes secuencias adaptadoras en cada posición. Una vez que una secuencia adaptadora se ve en una lectura, se cuenta como presente hasta el final de la lectura, por lo que el porcentaje aumenta con la longitud de la lectura. FastQC puede detectar algunos adaptadores por defecto (p.ej. Illumina, Nextera), para otros podemos proporcionar un archivo de contaminantes como entrada a la herramienta FastQC.
+
+Lo ideal sería que los datos de secuencia Illumina no tuvieran ninguna secuencia adaptadora. Pero con lecturas largas, algunas de las inserciones de la biblioteca son más cortas que la longitud de la lectura, lo que da lugar a una lectura a través del adaptador en el extremo 3' de la lectura. Esta muestra de microbioma tiene lecturas relativamente largas y podemos ver que se ha detectado el adaptador Nextera.
+
+> <details-title>Otros perfiles de contenido de adaptador</details-title>
+> 
+> El contenido de adaptadores también puede detectarse con bibliotecas RNA-Seq en las que la distribución de los tamaños de las inserciones de la biblioteca es variada y es probable que incluya algunas inserciones cortas.
+> 
+> ![Adapter Content](../../images/quality-control/adapter_content_rna_seq.png)
+> 
+{: .details}
+
+Podemos ejecutar una herramienta de recorte como Cutadapt para eliminar este adaptador. Explicaremos este proceso en la sección de filtrado y recorte.
+
+
+> <tip-title>Toma un atajo</tip-title>
+> 
+> Las siguientes secciones detallan algunos de los otros gráficos generados por FastQC. Tenga en cuenta que algunos gráficos/módulos pueden dar advertencias, pero son normales para el tipo de datos con los que está trabajando, como se explica a continuación y [en el FAQ de FASTQC](https://rtsf.natsci.msu.edu/genomics/tech-notes/fastqc-tutorial-and-faq/). Los otros gráficos nos dan información para entender más profundamente la calidad de los datos, y para ver si se pueden hacer cambios en el laboratorio para obtener datos de mayor calidad en el futuro. Estas secciones son **opcionales**, y si desea saltárselas puede hacerlo:
+>   - Vaya directamente a la [siguiente sección](#trim-and-filter---short-reads) para aprender sobre el recorte de datos de extremos pareados
+> 
+{: .tip}
+
+### Calidad de la secuencia por mosaico
+
+Este gráfico le permite observar las puntuaciones de calidad de cada mosaico en todas sus bases para ver si hubo una pérdida de calidad asociada a una sola parte de la celda de flujo. El gráfico muestra la desviación de la calidad media de cada mosaico de la célula de flujo. Los colores más vivos indican que las lecturas en el mosaico dado tienen peores calidades para esa posición que las lecturas en otros mosaicos. Con esta muestra, se puede ver que ciertos mosaicos muestran una calidad consistentemente pobre, especialmente a partir de ~100bp. Un buen gráfico debería ser azul en todas partes.
+
+![Per tile sequence quality](../../images/quality-control/per_tile_sequence_quality-before.png "Calidad de secuencia por mosaico")
+
+Este gráfico sólo aparecerá para las bibliotecas Illumina que conserven sus identificadores de secuencia originales. En ellos está codificada la celda de flujo de la que procede cada lectura.
+
+> <details-title>Otros perfiles de calidad de mosaico</details-title>
+> 
+> En algunos casos, los productos químicos utilizados durante la secuenciación se agotan un poco con el tiempo y los últimos mosaicos tienen peores productos químicos, lo que hace que las reacciones de secuenciación sean un poco propensas a errores. El gráfico "Calidad de la secuencia por mosaico" tendrá entonces algunas líneas horizontales como esta:
+> 
+> ![Calidad de secuencia por mosaico con líneas horizontales](../../images/quality-control/per_tile_sequence_quality_horizontal_lines.png)
+> 
+{: .details}
+
+## Puntuaciones de calidad por secuencia
+
+Traza la puntuación de calidad media sobre la longitud total de todas las lecturas en el eje x y da el número total de lecturas con esta puntuación en el eje y:
+
+![Puntuaciones de calidad por secuencia](../../images/quality-control/per_sequence_quality_scores-before.png "Puntuaciones de calidad por secuencia")
+
+La distribución de la calidad media de lectura debe ser pico apretado en el rango superior de la parcela. También puede informar si un subconjunto de las secuencias tiene valores de calidad universalmente bajos: puede ocurrir porque algunas secuencias tienen imágenes pobres (en el borde del campo de visión, etc.), sin embargo, éstas deberían representar sólo un pequeño porcentaje del total de secuencias.
+
+## Contenido de la secuencia por base
+
+![Contenido por secuencia de bases](../../images/quality-control/per_base_sequence_content-before.png "Contenido por secuencia de bases para una biblioteca de ADN")
+
+"Contenido de la secuencia por base" muestra el porcentaje de cada uno de los cuatro nucleótidos (T, C, A, G) en cada posición de todas las lecturas del archivo de secuencia de entrada. Como en el caso de la calidad de la secuencia por base, el eje x no es uniforme.
+
+En una biblioteca aleatoria esperaríamos que hubiera poca o ninguna diferencia entre las cuatro bases. La proporción de cada una de las cuatro bases debería permanecer relativamente constante a lo largo de la lectura con `%A=%T` y `%G=%C`, y las líneas de este gráfico deberían ser paralelas entre sí. Estos son datos de amplicón, donde el ADN 16S es amplificado por PCR y secuenciado, por lo que esperaríamos que este gráfico tuviera algún sesgo y no mostrara una distribución aleatoria.
+
+> <details-title>Biasis por tipo de biblioteca</details-title>
+> 
+> Cabe señalar que algunos tipos de bibliotecas siempre producirán una composición sesgada de la secuencia, normalmente al inicio de la lectura. Las bibliotecas producidas por cebado usando hexámeros aleatorios (incluyendo casi todas las bibliotecas RNA-Seq), y aquellas que fueron fragmentadas usando transposasas, contendrán un sesgo intrínseco en las posiciones en las que comienzan las lecturas (las primeras 10-12 bases). Este sesgo no implica una secuencia específica, sino que proporciona un enriquecimiento de una serie de diferentes K-mers en el extremo 5' de las lecturas. Aunque se trata de un verdadero sesgo técnico, no es algo que pueda corregirse recortando y, en la mayoría de los casos, no parece afectar negativamente al análisis posterior. Sin embargo, producirá una advertencia o un error en este módulo.
+> 
+> ![Contenido de secuencia por base para datos de ARN-seq](../../images/quality-control/per_base_sequence_content_rnaseq.png)
+> 
+> Los datos ChIP-seq también pueden encontrar sesgos en la secuencia de inicio de lectura en este gráfico si se fragmentan con transposasas. Con datos convertidos por bisulfito, por ejemplo datos HiC, se espera una separación de G de C y A de T:
+> 
+> ![Contenido de la secuencia por base para datos de bisulfito](../../images/quality-control/per_base_sequence_content_bisulphite.png)
+> 
+> Al final, hay un cambio general en la composición de la secuencia. Si el desplazamiento se correlaciona con una pérdida de calidad de la secuenciación, se puede sospechar que los errores se producen con un sesgo de secuencia más uniforme que las bibliotecas convertidas por bisulfito. El recorte de las secuencias solucionó este problema, pero si no se hubiera hecho habría tenido un efecto dramático en las llamadas de metilación que se hicieron.
+> 
+{: .details}
+
+> <question-title></question-title>
+> 
+> ¿Por qué hay una advertencia para los gráficos de contenido de secuencia por base?
+> 
+> > <solution-title></solution-title> Al principio de las secuencias, el contenido de secuencia por base no es realmente bueno y los porcentajes no son iguales, como se espera para datos de amplicón 16S.
+> > 
+> > 
+> {: .solution }
+> 
+{: .question}
+
+
+## Contenido GC por secuencia
+
+![Contenido GC por secuencia](../../images/quality-control/per_sequence_gc_content-before.png "Contenido GC por secuencia")
+
+Este gráfico muestra el número de lecturas frente al porcentaje de bases G y C por lectura. Se compara con una distribución teórica que asume un contenido uniforme de GC para todas las lecturas, esperado para la secuenciación de escopeta del genoma completo, donde el pico central corresponde al contenido general de GC del genoma subyacente. Dado que no se conoce el contenido de GC del genoma, se calcula el contenido modal de GC a partir de los datos observados y se utiliza para construir una distribución de referencia.
+
+Una distribución con forma inusual podría indicar una biblioteca contaminada o algún otro tipo de subconjunto sesgado. Una distribución normal desplazada indica algún sesgo sistemático, que es independiente de la posición de las bases. Si hay un sesgo sistemático que crea una distribución normal desplazada, el módulo no lo marcará como error, ya que no sabe cuál debería ser el contenido de GC de su genoma.
+
+Pero también hay otras situaciones en las que puede producirse una distribución de forma inusual. Por ejemplo, con la secuenciación de ARN puede haber una distribución mayor o menor del contenido medio de GC entre los transcritos, lo que hace que el gráfico observado sea más ancho o más estrecho que una distribución normal ideal.
+
+> <question-title></question-title>
+> 
+> ¿Por qué fallan los gráficos de contenido de GC por secuencia?
+> 
+> > <solution-title></solution-title> Hay múltiples picos. Esto puede ser indicativo de contaminación inesperada, como adaptador, ARNr o secuencias sobrerrepresentadas. O puede ser normal si se trata de datos de amplicón o si tiene transcritos de ARN-seq muy abundantes.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+### Distribución de la longitud de la secuencia
+
+Este gráfico muestra la distribución de tamaños de fragmentos en el archivo analizado. En muchos casos, esto producirá un simple gráfico que mostrará un pico en un solo tamaño, pero para los archivos FASTQ de longitud variable mostrará las cantidades relativas de cada tamaño diferente de fragmento de secuencia. Nuestro gráfico muestra la longitud variable a medida que recortamos los datos. El pico más grande está a 296 pb, pero hay un segundo pico grande a ~100 pb. Así que, aunque nuestras secuencias tienen una longitud de hasta 296 pb, muchas de las secuencias de buena calidad son más cortas. Esto se corresponde con la caída que observamos en la calidad de la secuencia a ~100 pb y las rayas rojas que comienzan en esta posición en el gráfico de calidad de la secuencia por mosaico.
+
+![Distribución de la longitud de secuencia](../../images/quality-control/sequence_length_distribution-before.png "Distribución de la longitud de secuencia")
+
+Algunos secuenciadores de alto rendimiento generan fragmentos de secuencias de longitud uniforme, pero otros pueden contener lecturas de longitudes muy variables. Incluso dentro de las bibliotecas de longitud uniforme, algunos pipelines recortarán las secuencias para eliminar las llamadas de bases de baja calidad del final o de las primeras $$n$$ bases si coinciden con las primeras $$n$$ bases del adaptador hasta un 90% (por defecto), con a veces $$n = 1$$.
+
+## Niveles de duplicación de secuencias
+
+El gráfico muestra en azul el porcentaje de lecturas de una secuencia dada en el archivo que están presentes un número determinado de veces en el archivo:
+
+![Niveles de duplicación de secuencias](../../images/quality-control/sequence_duplication_levels-before.png "Niveles de duplicación de secuencias")
+
+En una biblioteca diversa, la mayoría de las secuencias aparecerán sólo una vez en el conjunto final. Un nivel bajo de duplicación puede indicar un nivel muy alto de cobertura de la secuencia objetivo, pero un nivel alto de duplicación es más probable que indique algún tipo de sesgo de enriquecimiento.
+
+Se pueden encontrar dos fuentes de lecturas duplicadas:
+- Duplicación PCR en la que los fragmentos de la biblioteca se han sobre-representado debido a un enriquecimiento PCR sesgado
+
+  Es preocupante porque los duplicados de PCR falsean la proporción real de secuencias en la entrada.
+
+- Secuencias verdaderamente sobrerrepresentadas, como transcritos muy abundantes en una biblioteca de RNA-Seq o en datos de amplicón (como esta muestra)
+
+  Es un caso esperado y no es preocupante porque representa fielmente la entrada.
+
+> <details-title>Más detalles sobre la duplicación</details-title>
+> 
+> FastQC cuenta el grado de duplicación de cada secuencia en una biblioteca y crea un gráfico que muestra el número relativo de secuencias con diferentes grados de duplicación. Hay dos líneas en el gráfico:
+> - Línea azul: distribución de los niveles de duplicación para el conjunto completo de secuencias
+> - Línea roja: distribución para las secuencias deduplicadas con las proporciones del conjunto deduplicado que provienen de diferentes niveles de duplicación en los datos originales.
+> 
+> Para los datos de escopeta de genoma completo se espera que casi el 100% de sus lecturas sean únicas (que aparezcan sólo una vez en los datos de la secuencia). La mayoría de las secuencias deberían situarse en el extremo izquierdo del gráfico, tanto en la línea roja como en la azul. Esto indica que la biblioteca es muy diversa y que no se ha secuenciado en exceso. Si la profundidad de secuenciación es extremadamente alta (por ejemplo, > 100 veces el tamaño del genoma) puede aparecer alguna duplicación inevitable de secuencias: en teoría, sólo hay un número finito de lecturas de secuencias completamente únicas que pueden obtenerse a partir de cualquier muestra de ADN de entrada.
+> 
+> Los enriquecimientos más específicos de subconjuntos o la presencia de contaminantes de baja complejidad tenderán a producir picos hacia la derecha del gráfico. Estos picos de alta duplicación aparecerán con mayor frecuencia en el trazo azul, ya que constituyen una proporción elevada de la biblioteca original, pero suelen desaparecer en el trazo rojo, ya que constituyen una proporción insignificante del conjunto deduplicado. Si los picos persisten en el trazo rojo, esto sugiere que hay un gran número de secuencias diferentes altamente duplicadas, lo que podría indicar un conjunto contaminante o una duplicación técnica muy grave.
+> 
+> Suele ocurrir en la secuenciación de ARN que hay transcritos muy abundantes y otros poco abundantes. Es de esperar que se observen lecturas duplicadas para los transcritos de alta abundancia:
+> 
+> ![Niveles de duplicación de secuencias para RNA-seq](../../images/quality-control/sequence_duplication_levels_rna_seq.png)
+> 
+{: .details}
+
+## Secuencias sobrerrepresentadas
+
+Una biblioteca normal de alto rendimiento contendrá un conjunto diverso de secuencias, sin que ninguna secuencia individual represente una pequeña fracción del conjunto. Descubrir que una única secuencia está muy sobrerrepresentada en el conjunto significa que es altamente significativa desde el punto de vista biológico o indica que la biblioteca está contaminada o no es tan diversa como se esperaba.
+
+FastQC enumera todas las secuencias que representan más del 0,1% del total. Para cada secuencia sobrerrepresentada, FastQC buscará coincidencias en una base de datos de contaminantes comunes e informará de la mejor coincidencia que encuentre. Las coincidencias deben tener al menos 20 pb de longitud y no más de 1 desajuste. Encontrar una coincidencia no significa necesariamente que ésta sea la fuente de la contaminación, pero puede orientarle en la dirección correcta. También hay que tener en cuenta que muchas secuencias adaptadoras son muy similares entre sí, por lo que es posible que obtenga una coincidencia que no sea técnicamente correcta, pero que tenga una secuencia muy similar a la coincidencia real.
+
+Los datos de secuenciación de ARN pueden tener algunas transcripciones que son tan abundantes que se registran como secuencia sobrerrepresentada. Con los datos de secuenciación de ADN, ninguna secuencia debería estar presente con una frecuencia lo suficientemente alta como para aparecer en la lista, pero a veces podemos ver un pequeño porcentaje de lecturas adaptadoras.
+
+> <question-title></question-title>
+> 
+> ¿Cómo podríamos averiguar cuáles son las secuencias sobrerrepresentadas?
+> 
+> > <solution-title></solution-title> Podemos hacer BLAST con las secuencias sobrerrepresentadas para ver cuáles son. En este caso, si tomamos la secuencia más sobrerrepresentada
+> > ```
+> > >overrep_seq1
+> > GTGTCAGCCGCCGCGGTAGTCCGACGTGGCTGTCTCTTATACACATCTCC
+> > ```
+> > y usamos [blastn](https://blast.ncbi.nlm.nih.gov/Blast.cgi) contra la base de datos Nucleotide (nr/nt) por defecto no obtenemos ningún resultado. Pero si usamos [VecScreen](https://www.ncbi.nlm.nih.gov/tools/vecscreen/) vemos que es el adaptador Nextera. vecScreen](../../images/quality-control/vecscreen-nextera.png "Adaptador Nextera")
+> > 
+> {: .solution }
+> 
+{: .question}
+
+
+> <details-title>Más detalles sobre otros gráficos FastQC</details-title>
+> 
+> 
+> #### Contenido N por base
+> 
+> ![Contenido por base N](../../images/quality-control/per_base_n_content-before.png "Contenido por base N")
+> 
+> Si un secuenciador no puede realizar una llamada de base con suficiente confianza, escribirá una "N" en lugar de una llamada de base convencional. Este gráfico muestra el porcentaje de llamadas de base en cada posición o ubicación para las que se ha escrito una N.
+> 
+> No es inusual ver una proporción muy alta de Ns que aparecen en una secuencia, especialmente cerca del final de una secuencia. Pero esta curva nunca debería elevarse notablemente por encima de cero. Si lo hace, esto indica que se ha producido un problema durante la ejecución de la secuenciación. En el siguiente ejemplo, un error provocó que el instrumento no pudiera llamar una base en aproximadamente el 20% de las lecturas en la posición 29:
+> 
+> ![Contenido N por base](../../images/quality-control/per_base_n_content_error.png)
+> 
+> 
+> #### Contenido Kmer
+> 
+> Este gráfico no se muestra por defecto. Como se indica en el formulario de la herramienta, si desea utilizar este módulo, debe habilitarlo mediante un submódulo personalizado y un archivo de límites. Con este módulo, FastQC realiza un análisis genérico de todas las secuencias cortas de nucleótidos de longitud k (kmer, con k = 7 por defecto) comenzando en cada posición a lo largo de la lectura en la biblioteca para encontrar aquellas que no tienen una cobertura uniforme a lo largo de la longitud de sus lecturas. Cualquier kmer dado debe estar representado uniformemente en toda la longitud de la lectura.
+> 
+> FastQC informará de la lista de kmers que aparecen en posiciones específicas con una frecuencia mayor de la esperada. Esto puede deberse a diferentes fuentes de sesgo en la biblioteca, incluida la presencia de secuencias adaptadoras de lectura que se acumulan al final de las secuencias. La presencia de secuencias sobrerrepresentadas en la biblioteca (como dímeros de adaptador) hace que el gráfico de kmer esté dominado por el kmer de estas secuencias. Cualquier kmer sesgado debido a otros sesgos interesantes puede entonces diluirse y no ser fácil de ver.
+> 
+> El siguiente ejemplo es de una biblioteca DNA-Seq de alta calidad. Los kmers sesgados cerca del inicio de la lectura probablemente se deban a una ligera eficiencia dependiente de la secuencia del cizallamiento del ADN o a un resultado de cebado aleatorio:
+> 
+> ![Contenido Kmer](../../images/quality-control/kmer_content.png "Contenido Kmer")
+> 
+> Este módulo puede ser muy difícil de interpretar. El gráfico de contenido de adaptadores y la tabla de secuencias sobrerrepesentadas son más fáciles de interpretar y pueden darle suficiente información sin necesidad de este gráfico. Las bibliotecas RNA-seq pueden tener kmers altamente representados que derivan de secuencias altamente expresadas. Para obtener más información sobre este gráfico, consulte la [FastQC Kmer Content documentation](http://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/11%20Kmer%20Content.html).
+> 
+{: .details}
+
+Intentamos explicar aquí diferentes informes de FastQC y algunos casos de uso. Puede encontrar más información sobre este tema y también sobre algunos problemas comunes de secuenciación de nueva generación en [QCFAIL.com](https://sequencing.qcfail.com/)
+
+> <details-title>Problema específico para tipos de biblioteca alternativos</details-title>
+> 
+> #### ARN pequeño/micro
+> 
+> En las pequeñas bibliotecas de ARN, normalmente tenemos un conjunto relativamente pequeño de secuencias únicas y cortas. Las bibliotecas de ARN pequeño no se cizallan aleatoriamente antes de añadir adaptadores de secuenciación a sus extremos: todas las lecturas para clases específicas de microARN serán idénticas. El resultado será:
+> 
+> - Contenido de secuencia por base extremadamente sesgado
+> - Distribución extremadamente estrecha del contenido de GC
+> - Niveles muy altos de duplicación de secuencias
+> - Abundancia de secuencias sobrerrepresentadas
+> - Lectura en adaptadores
+> 
+> #### Amplicón
+> 
+> Las bibliotecas de amplicones se preparan mediante la amplificación por PCR de una diana específica. Por ejemplo, la región hipervariable V4 del gen 16S rRNA bacteriano. Se espera que todas las lecturas de este tipo de bibliotecas sean casi idénticas. El resultado será:
+> 
+> - Contenido de secuencia por base extremadamente sesgado
+> - Distribución extremadamente estrecha del contenido de GC
+> - Niveles muy altos de duplicación de secuencias
+> - Abundancia de secuencias sobrerrepresentadas
+> 
+> #### Secuenciación por bisulfito o metilación
+> 
+> Con bisulfito o secuenciación por metilación, la mayoría de las bases de citosina (C) se convierten en timina (T). El resultado será:
+> 
+> - Contenido sesgado de la secuencia por base
+> - Contenido de GC sesgado por secuencia
+> 
+> #### Contaminación de dímeros adaptadores
+> 
+> Cualquier tipo de biblioteca puede contener un porcentaje muy pequeño de fragmentos dímeros de adaptador (es decir, sin inserción). Es más probable encontrarlos en bibliotecas de amplicones construidas totalmente por PCR (por formación de dímeros de cebadores PCR) que en bibliotecas DNA-Seq o RNA-Seq construidas por ligadura de adaptadores. Si una fracción suficiente de la biblioteca está formada por dímeros de adaptador, se notará en el informe FastQC:
+> 
+> - Caída de la calidad de la secuencia por base después de la base 60
+> - Posible distribución bimodal de las puntuaciones de calidad por secuencia
+> - Patrón distinto observado en el contenido de la secuencia por base hasta la base 60
+> - Pico en el contenido de GC por secuencia
+> - Adaptador de coincidencia de secuencia sobrerrepresentada
+> - Contenido de adaptador > 0% a partir de la base 1
+> 
+{: .details}
+
+> <comment-title>Secuencias de mala calidad</comment-title> Si la calidad de las lecturas no es buena, siempre debemos comprobar primero qué es lo que está mal y pensar en ello: puede venir del tipo de secuenciación o de lo que secuenciamos (gran cantidad de secuencias sobrerrepresentadas en datos transcriptómicos, porcentaje sesgado de bases en datos HiC).
+> 
+> También puede preguntar en el centro de secuenciación, especialmente si la calidad es realmente mala: los tratamientos de calidad no pueden resolverlo todo. Si se cortan demasiadas bases de mala calidad, las lecturas correspondientes se filtrarán y se perderán.
+> 
+{: .comment}
+
+# Recorte y filtrado - lecturas cortas
+
+La calidad desciende en el centro de estas secuencias. Esto podría causar sesgos en los análisis posteriores con estos nucleótidos potencialmente mal llamados. Las secuencias deben ser tratadas para reducir el sesgo en los análisis posteriores. El recorte puede ayudar a aumentar el número de lecturas que el alineador o el ensamblador son capaces de utilizar con éxito, reduciendo el número de lecturas que quedan sin mapear o ensamblar. En general, los tratamientos de calidad incluyen:
+
+1. Recorte/corte/enmascaramiento de secuencias
+    - de regiones de baja puntuación de calidad
+    - principio/final de secuencia
+    - eliminación de adaptadores
+2. Filtrado de secuencias
+    - con una puntuación media de calidad baja
+    - demasiado corto
+    - con demasiadas bases ambiguas (N)
+
+Para llevar a cabo esta tarea utilizaremos [Cutadapt](https://cutadapt.readthedocs.io/en/stable/guide.html) {% cite marcel2011cutadapt %}, una herramienta que mejora la calidad de la secuencia automatizando el recorte de adaptadores así como el control de calidad. Lo haremos:
+
+- Recorte de bases de baja calidad de los extremos. El recorte de calidad se realiza antes de cualquier recorte de adaptador. Estableceremos el umbral de calidad en 20, un umbral de uso común, ver más [en GATK's Phred Score FAQ](https://gatk.broadinstitute.org/hc/en-us/articles/360035531872-Phred-scaled-quality-scores).
+- Recorte del adaptador con Cutadapt. Para ello necesitamos suministrar la secuencia del adaptador. En este ejemplo, Nextera es el adaptador detectado. Podemos encontrar la secuencia del adaptador Nextera en el [sitio web de Illumina aquí](https://support.illumina.com/bulletins/2016/12/what-sequences-do-i-use-for-adapter-trimming.html) `CTGTCTCTTATACACATCT`. Recortaremos esa secuencia del extremo 3' de las lecturas.
+- Filtro de secuencias con longitud < 20 después del recorte
+
+> <hands-on-title>Mejora de la calidad de la secuencia</hands-on-title>
+> 
+> 1. {% tool [Cutadapt](toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.9+galaxy1) %} con los siguientes parámetros
+>    - *"¿Lecturas de extremo único o de extremo pareado? "*: `Single-end`
+>       - {% icon param-file %} *"FASTQ/A file "*: `Reads` (Conjunto de datos de entrada)
+> 
+>         > <tip-title>¿Archivos no seleccionables?</tip-title> Si su archivo FASTQ no se puede seleccionar, puede comprobar si el formato es FASTQ con valores de calidad escalados por Sanger (`fastqsanger.gz`). Puede editar el tipo de datos haciendo clic en el símbolo del lápiz.
+> > 
+>          {: .tip}
+> 
+>    - En *"Read 1 Adapters "*:
+>       - *"1: 3' (Fin) Adapters "*:
+>          - *"Fuente "*: `Enter custom sequence`
+>          - *"Secuencia adaptadora 3' personalizada "*: `CTGTCTCTTATACACATCT`
+>    - En *"Otras opciones de recorte de lectura "*
+>       - *"Corte(s) de calidad (R1) "*: `20`
+>    - En *"Read Filtering Options "* (Opciones de filtrado de lectura)
+>       - *"Longitud mínima (R1) "*: `20`
+>    - {% icon param-select %} *"Resultados adicionales a generar "*: `Report`
+> 
+> 2. Inspeccione el archivo txt generado (`Report`)
+> 
+>    > <question-title></question-title>
+>    > 
+>    > 1. ¿Qué % de lecturas contienen adaptador?
+>    > 2. ¿Qué % de lecturas se han recortado por mala calidad?
+>    > 3. ¿Qué % de lecturas se han eliminado por ser demasiado cortas?
+>    > 
+>    > > <solution-title></solution-title>
+>    > > 1. 56.8% lecturas contienen adaptador (`Reads with adapters:`)
+>    > > 2. El 35,1% de las lecturas han sido recortadas por mala calidad (`Quality-trimmed:`)
+>    > > 3. 0 % de lecturas eliminadas por ser demasiado cortas
+> > > 
+> > {: .solution }
+> > 
+> {: .question}
+> 
+{: .hands_on}
+
+
+> <details-title>Recorte con Cutadapt</details-title>
+> 
+> Una de las mayores ventajas de Cutadapt en comparación con otras herramientas de recorte (¡por ejemplo TrimGalore!) es que tiene una buena [documentación](https://cutadapt.readthedocs.io) que explica cómo funciona la herramienta en detalle.
+> 
+> El algoritmo de recorte de calidad Cutadapt consta de tres sencillos pasos:
+> 
+> 1. Reste el valor umbral elegido del valor de calidad de cada posición
+> 2. Calcule una suma parcial de estas diferencias desde el final de la secuencia hasta cada posición (siempre que la suma parcial sea negativa)
+> 3. Corte en el valor mínimo de la suma parcial
+> 
+> En el siguiente ejemplo, suponemos que el extremo 3' debe ser de calidad recortada con un umbral de 10 y tenemos los siguientes valores de calidad
+> 
+> ```
+> 42 40 26 27 8 7 11 4 2 3
+> ```
+> 
+> 1. Restar el umbral
+> 
+>     ```
+>     32 30 16 17 -2 -3 1 -6 -8 -7
+>     ```
+> 
+> 2. Sume los números, empezando por el extremo 3' (sumas parciales) y deténgase antes si la suma es mayor que cero
+> 
+>     ```
+>     (70) (38) 8 -8 -25 -23 -20, -21 -15 -7
+>     ```
+> 
+>    Los números entre paréntesis no se calculan (porque 8 es mayor que cero), pero se muestran aquí para completar.
+> 
+> 3. Elija la posición del mínimo (`-25`) como posición de recorte
+> 
+> Por lo tanto, la lectura se recorta a las cuatro primeras bases, que tienen valores de calidad
+> 
+> ```
+> 42 40 26 27
+> ```
+> 
+> Obsérvese que, por lo tanto, las posiciones con un valor de calidad superior al umbral elegido también se eliminan si están incrustadas en regiones de menor calidad (la suma parcial es decreciente si los valores de calidad son inferiores al umbral). La ventaja de este procedimiento es que es robusto frente a un pequeño número de posiciones con una calidad superior al umbral.
+> 
+> 
+> Las alternativas a este procedimiento serían:
+> 
+> * Corte tras la primera posición con una calidad inferior al umbral
+> * Enfoque de ventana deslizante
+> 
+>   El enfoque de la ventana deslizante comprueba que la calidad media de cada ventana de secuencia de longitud especificada sea mayor que el umbral. Tenga en cuenta que, a diferencia del enfoque de cutadapt, este enfoque tiene un parámetro más y la robustez depende de la longitud de la ventana (en combinación con el umbral de calidad). Ambos enfoques están implementados en Trimmomatic.
+> 
+{: .details}
+
+
+Podemos examinar nuestros datos recortados con FASTQE y/o FastQC.
+
+> <hands-on-title>Comprobación de la calidad tras el recorte</hands-on-title>
+> 
+> 1. {% tool [FASTQE](toolshed.g2.bx.psu.edu/repos/iuc/fastqe/fastqe/0.3.1+galaxy0) %}: Vuelva a ejecutar **FASTQE** con los siguientes parámetros
+>    - {% icon param-files %} *"FastQ data "*: `Cutadapt Read 1 Output`
+>    - {% icon param-select %} *"Tipos de puntuación a mostrar "*: `Mean`
+> 
+> 2. Inspeccione el nuevo informe FASTQE
+> 
+>    > <question-title></question-title>
+>    > 
+>    > Compare la salida FASTQE con la anterior antes del recorte anterior. ¿Ha mejorado la calidad de la secuencia?
+>    > 
+>    > {% snippet faqs/galaxy/features_scratchbook.md %}
+>    > 
+>    > > <solution-title></solution-title> Sí, los emojis de puntuación de calidad se ven mejor (más felices) ahora.
+>    > > 
+>    > > ![FASTQE before](../../images/quality-control/fastqe-mean-before.png "Antes del recorte")
+>    > > 
+>    > > ![FASTQE after](../../images/quality-control/fastqe-mean-after.png "Después del recorte")
+>    > > 
+> > > 
+> > {: .solution }
+> > 
+> {: .question}
+> 
+{: .hands_on}
+
+Con FASTQE podemos ver que hemos mejorado la calidad de las bases en el conjunto de datos.
+
+También podemos, o en su lugar, comprobar los datos de calidad controlada con FastQC.
+
+
+> <hands-on-title>Comprobación de la calidad tras el recorte</hands-on-title>
+> 
+> 1. {% tool [FASTQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0) %} con los siguientes parámetros
+>    - {% icon param-files %} *"Datos de lecturas cortas de su historial actual "*: `Cutadapt Read 1 Output`
+> 
+> 2. Inspeccione el archivo HTML generado
+> 
+{: .hands_on}
+
+> <question-title></question-title>
+> 1. ¿La calidad de la secuencia por base parece mejor?
+> 2. ¿Ha desaparecido el adaptador?
+> 
+> > <solution-title></solution-title>
+> > 1. Sí. La gran mayoría de las bases tienen una puntuación de calidad por encima de 20 ahora. calidad de la secuencia por base](../../images/quality-control/per_base_sequence_quality-after.png "Calidad de la secuencia por base")
+> > 
+> > 2. Sí. Ahora no se detecta ningún adaptador. contenido del adaptador](../../images/quality-control/adapter_content-after.png)
+> > 
+> {: .solution }
+> 
+{: .question}
+
+Con FastQC podemos ver que mejoramos la calidad de las bases en el conjunto de datos y eliminamos el adaptador.
+
+> <details-title>Otros gráficos FastQC tras el recorte</details-title>
+> 
+> ![Per tile sequence quality](../../images/quality-control/per_tile_sequence_quality-after.png) Tenemos algunas rayas rojas porque hemos recortado esas regiones de las lecturas.
+> 
+> ![Per sequence quality scores](../../images/quality-control/per_sequence_quality_scores-after.png) Ahora tenemos un pico de alta calidad en lugar de uno de alta y otro de baja calidad que teníamos anteriormente.
+> 
+> ![Per base sequence content](../../images/quality-control/per_base_sequence_content-after.png) No tenemos la misma representación de las bases que antes, ya que se trata de datos de amplicones.
+> 
+> ![Per sequence GC content](../../images/quality-control/per_sequence_gc_content-after.png) Ahora tenemos un único pico principal de GC debido a la eliminación del adaptador.
+> 
+> ![Contenido N por base](../../images/quality-control/per_base_n_content-after.png) Esto es lo mismo que antes, ya que no tenemos Ns en estas lecturas.
+> 
+> ![Sequence length distribution](../../images/quality-control/sequence_length_distribution-after.png) Ahora tenemos múltiples picos y un rango de longitudes, en lugar del único pico que teníamos antes del recorte cuando todas las secuencias tenían la misma longitud.
+> 
+> ![Niveles de duplicación de secuencias](../../images/quality-control/sequence_duplication_levels-after.png)
+> > <question-title></question-title>
+> > 
+> > ¿A qué corresponde la secuencia más sobrerrepresentada `GTGTCAGCCGCCGCGGTAGTCCGACGTGG`?
+> > 
+> > > <solution-title></solution-title> Si tomamos la secuencia más sobrerrepresentada
+> > > ```
+> > > >overrep_seq1_after
+> > > GTGTCAGCCGCCGCGGTAGTCCGACGTGG
+> > > ```
+> > > y usamos [blastn](https://blast.ncbi.nlm.nih.gov/Blast.cgi) contra la base de datos por defecto Nucleotide (nr/nt) vemos que los resultados más altos son para genes 16S rRNA. Esto tiene sentido, ya que se trata de datos de amplicones 16S, en los que el gen 16S se amplifica por PCR.
+> > > 
+> > {: .solution }
+> > 
+> {: .question}
+> 
+{: .details}
+
+
+# Procesamiento de múltiples conjuntos de datos
+
+## Procesamiento de datos por pares
+
+En la secuenciación por pares, los fragmentos se secuencian por ambos lados. Este enfoque da lugar a dos lecturas por fragmento, con la primera lectura orientada hacia delante y la segunda hacia atrás. Con esta técnica, tenemos la ventaja de obtener más información sobre cada fragmento de ADN en comparación con las lecturas secuenciadas únicamente por secuenciación de un solo extremo:
+
+```
+    ------>                       [single-end]
+
+    ----------------------------- [fragment]
+
+    ------>               <------ [paired-end]
+```
+Se conoce la distancia entre ambas lecturas y, por lo tanto, es información adicional que puede mejorar el mapeo de lecturas.
+
+La secuenciación por pares genera 2 archivos FASTQ:
+- Un archivo con las secuencias correspondientes a la orientación **hacia adelante** de todos los fragmentos
+- Un archivo con las secuencias correspondientes a la orientación **inversa** de todos los fragmentos
+
+Normalmente reconocemos estos dos archivos que pertenecen a una muestra por el nombre que tiene el mismo identificador para las lecturas pero una extensión diferente, por ejemplo `sampleA_R1.fastq` para las lecturas hacia adelante y `sampleA_R2.fastq` para las lecturas hacia atrás. También puede ser `_f` o `_1` para las lecturas directas y `_r` o `_2` para las lecturas inversas.
+
+Los datos que analizamos en el paso anterior eran datos de extremo único, por lo que importaremos un conjunto de datos de ARN-seq de extremo pareado. Ejecutaremos FastQC y agregaremos los dos informes con MultiQC {% cite ewels2016multiqc %}.
+
+> <hands-on-title>Evaluación de la calidad de las lecturas paired-end</hands-on-title>
+> 
+> 1. Importe las lecturas pareadas `GSM461178_untreat_paired_subset_1.fastq` y `GSM461178_untreat_paired_subset_2.fastq` de [Zenodo](https://zenodo.org/record/61771) o de la biblioteca de datos (pregunte a su instructor)
+> 
+>    ```
+>    https://zenodo.org/record/61771/files/GSM461178_untreat_paired_subset_1.fastq
+>    https://zenodo.org/record/61771/files/GSM461178_untreat_paired_subset_2.fastq
+>    ```
+> 
+> 2. {% tool [FASTQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0) %} con ambos conjuntos de datos:
+>    - {% icon param-files %} *"Raw read data from your current history "*: ambos conjuntos de datos cargados.
+> 
+>    {% snippet faqs/galaxy/tools_select_multiple_datasets.md %}
+> 
+> 3. {% tool [MultiQC](toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9+galaxy1) %} with the following parameters to aggregate the FastQC reports of both forward and reverse reads
+>      - En *"Resultados "*
+>        - *"¿Qué herramienta se utilizó para generar los registros?*: `FastQC`
+>        - En *"FastQC output "* (Salida de FastQC)
+>           - *"¿Tipo de salida FastQC? "*: `Raw data`
+>           - {% icon param-files %} *"FastQC output "*: archivos `Raw data` (salida de ambos **FastQC** {% icon tool %})
+> 
+> 4. Inspeccione la página web de MultiQC.
+> 
+{: .hands_on}
+
+
+> <question-title></question-title>
+> 
+> 1. ¿Qué opina de la calidad de las secuencias?
+> 2. ¿Qué debemos hacer?
+> 
+> > <solution-title></solution-title>
+> > 
+> > 1. La calidad de las secuencias parece peor para las lecturas inversas que para las lecturas directas:
+> >     - Puntuaciones de calidad por secuencia: distribución más a la izquierda, es decir, una menor calidad media de las secuencias
+> >     - Calidad de la secuencia por base: curva menos suave y mayor disminución al final con un valor medio inferior al 28
+> >     - Contenido de la secuencia por base: sesgo más fuerte al principio y sin distinción clara entre los grupos C-G y A-T
+> > 
+> >    Los demás indicadores (adaptadores, niveles de duplicación, etc.) son similares.
+> > 
+> > 2. Deberíamos recortar el final de las secuencias y filtrarlas con **Cutadapt** {% icon tool %}
+> > 
+> {: .solution}
+> 
+{: .question}
+
+Con lecturas pareadas, las puntuaciones medias de calidad de las lecturas hacia delante serán casi siempre superiores a las de las lecturas hacia atrás.
+
+Tras el recorte, las lecturas inversas serán más cortas debido a su calidad y se eliminarán durante el paso de filtrado. Si se elimina una de las lecturas inversas, debe eliminarse también su correspondiente lectura directa. De lo contrario, obtendremos un número diferente de lecturas en ambos archivos y en diferente orden, y el orden es importante para los siguientes pasos. Por lo tanto, **es importante tratar las lecturas directas e inversas juntas para recortarlas y filtrarlas**.
+
+> <hands-on-title>Mejorando la calidad de los datos paired-end</hands-on-title>
+> 1. {% tool [Cutadapt](toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.9+galaxy1) %} con los siguientes parámetros
+>    - *"¿Lecturas de extremo único o de extremo pareado? "*: `Paired-end`
+>       - {% icon param-file %} *"FASTQ/A file #1"*: `GSM461178_untreat_paired_subset_1.fastq` (Input dataset)
+>       - {% icon param-file %} *"FASTQ/A file #2"*: `GSM461178_untreat_paired_subset_2.fastq` (Input dataset)
+> 
+>         ¡El orden es importante aquí!
+> 
+>       - En *Lectura 1 Adaptadores* o *Lectura 2 Adaptadores*
+> 
+>         No se encontraron adaptadores en estos conjuntos de datos. Cuando procese sus propios datos y sepa qué secuencias de adaptador se utilizaron durante la preparación de la biblioteca, debe proporcionar sus secuencias aquí.
+> 
+>    - En *"Otras opciones de recorte de lectura "*
+>       - *"Corte(s) de calidad (R1) "*: `20`
+>    - En *"Read Filtering Options "* (Opciones de filtrado de lectura)
+>       - *"Longitud mínima (R1) "*: `20`
+>    - {%icon param-select%} *"Resultados adicionales a generar "*: `Report`
+> 
+> 2. Inspeccione el archivo txt generado (`Report`)
+> 
+>    > <question-title></question-title>
+>    > 
+>    > 1. ¿Cuántos pares de bases se han eliminado de las lecturas debido a la mala calidad?
+>    > 2. ¿Cuántos pares de secuencias se han eliminado por ser demasiado cortos?
+>    > 
+>    > > <solution-title></solution-title>
+>    > > 1. 44.164 pb (`Quality-trimmed:`) para las lecturas hacia adelante y 138.638 pb para las lecturas hacia atrás.
+>    > > 2. Se han eliminado 1.376 secuencias porque al menos una lectura era más corta que el corte de longitud (322 cuando sólo se analizaron las lecturas hacia adelante).
+> > > 
+> > {: .solution }
+> > 
+> {: .question}
+> 
+{: .hands_on}
+
+Además del informe, Cutadapt genera 2 archivos:
+- Lectura 1 con las lecturas forward recortadas y filtradas
+- Lectura 2 con las lecturas inversas recortadas y filtradas
+
+Estos conjuntos de datos pueden utilizarse para el análisis posterior, por ejemplo, el mapeo.
+
+> <question-title></question-title>
+> 
+> 1. ¿Qué tipo de alineación se utiliza para encontrar adaptadores en las lecturas?
+> 2. ¿Cuál es el criterio para elegir la mejor alineación de adaptadores?
+> 
+> > <solution-title></solution-title>
+> > 
+> > 1. Alineación semiglobal, es decir, sólo se utiliza para la puntuación la parte solapada de la lectura y la secuencia adaptadora.
+> > 2. Se calcula un alineamiento con solapamiento máximo que tiene el menor número de desajustes e indels.
+> > 
+> {: .solution}
+> 
+{: .question}
+
+# Evaluar la calidad con Nanoplot - Sólo lecturas largas
+
+En caso de lecturas largas, podemos comprobar la calidad de la secuencia con [Nanoplot](https://github.com/wdecoster/NanoPlot/) ({% cite 10.1093/bioinformatics/bty149 %}). Proporciona estadísticas básicas con bonitos gráficos para un rápido control de calidad.
+
+> <hands-on-title>Comprobación de la calidad de las lecturas largas</hands-on-title>
+> 1. Crea un nuevo historial para esta parte y dale un nombre apropiado
+> 
+> 2. Importe las lecturas PacBio HiFi `m64011_190830_220126.Q20.subsample.fastq.gz` de [Zenodo](https://zenodo.org/record/5730295)
+> 
+>    ```
+>    https://zenodo.org/records/5730295/files/m64011_190830_220126.Q20.subsample.fastq.gz
+>    ```
+> 
+> 3. {% tool [Nanoplot](toolshed.g2.bx.psu.edu/repos/iuc/nanoplot/nanoplot/1.41.0+galaxy0) %} con los siguientes parámetros
+>    - {% icon param-files %} *"files "*: `m64011_190830_220126.Q20.subsample.fastq.gz`
+>    - *"Opciones para personalizar los gráficos creados "*
+>        - {% icon param-select %} *"Especifica el formato bivariante de los gráficos. "*: `dot`, `kde`
+>        - {% icon param-select %} *"Mostrar la marca N50 en el histograma de longitud de lectura. "*: `Yes`
+> 
+> 4. Inspeccione el archivo HTML generado
+> 
+{: .hands_on}
+
+> <question-title></question-title>
+> 
+> ¿Cuál es el Qscore medio?
+> 
+> > <solution-title></solution-title> El Qscore está en torno a Q32. En el caso de PacBio CLR y Nanopore, está alrededor de Q12 y cerca de Q31 para Illumina (NovaSeq 6000). ![Gráfico de Qscore entre Illumina, PacBio y Nanopore](../../images/quality-control/qscore-illumina-pacbio-nanopore.png "Comparación de Qscore entre Illumina, PacBio y Nanopore")
+> > 
+> > Definición: Qscores es la probabilidad media de error por base, expresada en la escala log (Phred)
+> > 
+> {: .solution }
+> 
+> ¿Cuál es la mediana, la media y N50?
+> > <solution-title></solution-title> La mediana, la longitud media de lectura y el N50 también están cerca de 18.000 pb. Para las lecturas PacBio HiFi, la mayoría de las lecturas están generalmente cerca de este valor ya que la preparación de la biblioteca incluye un paso de selección de tamaño. Para otras tecnologías como PacBio CLR y Nanopore, es mayor y depende principalmente de la calidad de la extracción de ADN.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+## Histograma de longitudes de lectura
+
+Este gráfico muestra la distribución de tamaños de fragmentos en el archivo analizado. A diferencia de la mayoría de las ejecuciones de Illumina, las lecturas largas tienen una longitud variable y esto mostrará las cantidades relativas de cada tamaño diferente de fragmento de secuencia. En este ejemplo, la distribución de la longitud de lectura se centra cerca de 18kbp pero los resultados pueden ser muy diferentes dependiendo de su experimento.
+
+![Histograma de longitudes de lectura](../../images/quality-control/HistogramReadlength.png "Histograma de longitud de lectura")
+
+## Gráfico de longitudes de lectura frente a calidad media de lectura mediante puntos
+
+Este gráfico muestra la distribución del tamaño de los fragmentos en función de la puntuación Q del archivo analizado. En general, no hay relación entre la longitud de la lectura y la calidad de la lectura, pero esta representación permite visualizar ambas informaciones en un único gráfico y detectar posibles aberraciones. En corridas con muchas lecturas cortas las lecturas más cortas son a veces de menor calidad que el resto.
+
+![Gráfico de longitudes de lectura frente a calidad media de lectura mediante puntos](../../images/quality-control/LengthvsQualityScatterPlot_dot.png "Histograma de longitud de lectura")
+
+> <question-title></question-title> Observando el "Gráfico de longitudes de lectura frente a calidad media de lectura utilizando el gráfico de puntos". ¿Notaste algo inusual con el Qscore? ¿Puede explicarlo?
+> > <solution-title></solution-title> No hay lecturas bajo Q20. La calificación para las lecturas HiFi es:
+> > - Un número mínimo de 3 subreads
+> > - A read Qscore >=20 ![PacBio HiFi sequencing](../../images/quality-control/pacbio-css-hifi-sequencing.png "PacBio HiFi sequencing")
+> > 
+> {: .solution }
+> 
+{: .question}
+
+> <comment-title>¡Pruébelo!</comment-title> Haga el control de calidad con **FastQC** {% icon tool %} en `m64011_190830_220126.Q20.subsample.fastq.gz` y compare los resultados!
+> 
+{: .comment}
+
+# Evaluar la calidad con PycoQC - Sólo Nanopore
+
+[PycoQC](https://github.com/tleonardi/pycoQC) ({% cite Leger2019 %}) es una herramienta de visualización de datos y control de calidad para datos de nanoporos. A diferencia de FastQC/Nanoplot, necesita un archivo específico sequencing_summary.txt generado por Oxford nanopore basecallers como Guppy o el antiguo albacore basecaller.
+
+Uno de los puntos fuertes de PycoQC es que es interactivo y altamente personalizable, por ejemplo, los gráficos se pueden recortar, se puede acercar y alejar, sub-seleccionar áreas y exportar figuras.
+
+> <hands-on-title>Comprobación de calidad de las lecturas Nanopore</hands-on-title>
+> 1. Crea un nuevo historial para esta parte y dale un nombre apropiado
+> 
+> 2. Importar las lecturas nanopore `nanopore_basecalled-guppy.fastq.gz` y `sequencing_summary.txt` de [Zenodo](https://zenodo.org/record/5730295)
+> 
+>    ```
+>    https://zenodo.org/records/5730295/files/nanopore_basecalled-guppy.fastq.gz
+>    https://zenodo.org/records/5730295/files/sequencing_summary.txt
+>    ```
+> 
+> 3. {% tool [PycoQC](toolshed.g2.bx.psu.edu/repos/iuc/pycoqc/pycoqc/2.5.2+galaxy0) %} con los siguientes parámetros
+> 
+>    - {% icon param-files %} *"A sequencing_summary file "*: `sequencing_summary.txt`
+> 
+> 4. Inspeccione la salida de la página web de PycoQC
+> 
+{: .hands_on}
+
+> <question-title></question-title>
+> 
+> ¿Cuántas lecturas tiene en total?
+> > <solution-title></solution-title> ~270k lecturas en total (ver la tabla de resumen de Basecall, "All reads") Para la mayoría de los perfiles de basecall, Guppy asignará lecturas como "Pass" si el Qscore de la lectura es al menos igual a 7.
+> > 
+> {: .solution }
+> 
+> ¿Cuál es la mediana, el mínimo y el máximo de longitud de lectura, y cuál es el N50?
+> > <solution-title></solution-title> La mediana de la longitud de lectura y el N50 se pueden encontrar para todos, así como para todas las lecturas aprobadas, es decir, las lecturas que pasaron los ajustes de calidad de Guppy (Qscore >= 7), en la tabla de resumen basecall. Para las longitudes de lectura mínima (195bp) y máxima (256kbp), se puede encontrar con el gráfico de longitudes de lectura.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+## Longitud de las lecturas base
+
+Como para FastQC y Nanoplot, este gráfico muestra la distribución de tamaños de fragmentos en el archivo analizado. En cuanto a PacBio CLR/HiFi, las lecturas largas tienen una longitud variable y esto mostrará las cantidades relativas de cada tamaño diferente de fragmento de secuencia. En este ejemplo, la distribución de la longitud de lectura es bastante dispersa, con una longitud de lectura mínima para las lecturas pasadas de alrededor de 200 pb y una longitud máxima de ~150.000 pb.
+
+![Basecalled reads length](../../images/quality-control/basecalled_reads_length-pycoqc.png "Basecalled reads length")
+
+### Calidad PHRED de las lecturas por base
+
+Este gráfico muestra la distribución de las puntuaciones de calidad (Q) para cada lectura. Esta puntuación pretende dar una puntuación de calidad global para cada lectura. La definición exacta de Qscores es: la probabilidad media de error por base, expresada en la escala log (Phred). En el caso de los datos Nanopore, la distribución se centra generalmente en torno a 10 o 12. En el caso de ejecuciones antiguas, la distribución puede ser menor, ya que los modelos de basecalling son menos precisos que los modelos recientes.
+
+![Basecalled reads PHRED quality](../../images/quality-control/basecalled_reads_PHRED_quality-pycoqc.png "Basecalled reads PHRED quality")
+
+## Longitud de las lecturas por base frente a la calidad de las lecturas PHRED
+
+> <question-title></question-title> ¿Qué aspecto tienen la calidad media y la distribución de la calidad del experimento?
+> > <solution-title></solution-title> La mayoría de las lecturas tienen un Qscore entre 8 y 11 que es estándar para los datos Nanopore. Tenga en cuenta que para los mismos datos, el basecaller utilizado (Albacor, Guppy, Bonito), el modelo (fast, hac, sup) y la versión de la herramienta pueden dar resultados diferentes.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+Al igual que NanoPlot, esta representación ofrece una visualización en 2D de la puntuación Q de las lecturas en función de su longitud.
+
+![Basecalled reads length vs reads PHRED quality](../../images/quality-control/basecalled_reads_length_vs_reads_PHRED_quality-pycoqc.png "Basecalled reads length vs reads PHRED quality")
+
+## Resultados durante el experimento
+
+Esta representación ofrece información sobre las lecturas secuenciadas a lo largo del tiempo para una única ejecución:
+
+- Cada imagen indica una nueva carga de la celda de flujo (3 + la primera carga).
+- La contribución en lecturas totales para cada "recarga".
+- La producción de lecturas está disminuyendo con el tiempo:
+  - Se secuencia la mayor parte del material (ADN/ARN)
+  - Saturación de poros
+  - Degradación de material/poros
+  - ...
+
+En este ejemplo, la contribución de cada repostaje es muy baja, y puede considerarse una mala ejecución. El área del gráfico "Acumulativo" (azul claro) indica que el 50% de todas las lecturas y casi el 50% de todas las bases se produjeron en las primeras 5h del experimento de 25h. Aunque es normal que el rendimiento disminuya con el tiempo, una disminución como ésta no es una buena señal.
+
+![Output over experiment time](../../images/quality-control/output_over_experiment_time-pycoqc.png "Output over experiment time")
+
+> <details-title>Otro perfil de "Salida a lo largo del tiempo del experimento"</details-title>
+> 
+> En este ejemplo, la producción de datos a lo largo del tiempo sólo disminuyó ligeramente durante las 12h con un aumento continuo de los datos acumulados. La ausencia de una curva decreciente al final del experimento indica que todavía hay material biológico en la celda de flujo. El experimento finalizó antes de que se secuenciara todo. Es una corrida excelente, incluso puede considerarse como excepcional.
+> 
+> ![Output over experiment time good profile](../../images/quality-control/output_over_experiment_time-pycoqc-good.png)
+> 
+{: .details}
+
+### Longitud de lectura durante el experimento
+
+> <question-title></question-title> ¿Ha cambiado la longitud de la lectura con el tiempo? ¿Cuál podría ser la razón?
+> > <solution-title></solution-title> En el ejemplo actual, la longitud de la lectura aumenta con el tiempo de la carrera de secuenciación. Una explicación es que la densidad del adaptador es mayor para muchos fragmentos cortos y, por tanto, la posibilidad de que un fragmento más corto se adhiera a un poro es mayor. Además, las moléculas más cortas pueden desplazarse más rápidamente por el chip. Sin embargo, con el tiempo, los fragmentos más cortos son cada vez más raros y, por tanto, son más los fragmentos largos que se adhieren a los poros y se secuencian.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+La longitud de lectura a lo largo del experimento debería ser estable. Puede aumentar ligeramente a lo largo del tiempo, ya que los fragmentos cortos tienden a sobre-secuenciarse al principio y están menos presentes a lo largo del tiempo.
+
+![Longitud de lectura sobre tiempo de experimento](../../images/quality-control/read_length_over_experiment_time-pycoqc.png "Longitud de lectura sobre tiempo de experimento")
+
+## Actividad del canal en el tiempo
+
+Ofrece una visión general de los poros disponibles, el uso de los poros durante el experimento, los poros inactivos y muestra si la carga de la celda de flujo es buena (se utilizan casi todos los poros). En este caso, la gran mayoría de canales/poros están inactivos (blanco) durante todo el experimento de secuenciación, por lo que el experimento puede considerarse malo.
+
+Es de esperar que el gráfico sea oscuro cerca del eje X y que con valores Y más altos (tiempo creciente) no se vuelva demasiado claro/blanco. Dependiendo de si elige "Reads" o "Bases" a la izquierda, el color indica el número de bases o de lecturas por intervalo de tiempo
+
+![Actividad del canal en el tiempo](../../images/quality-control/channel_activity_over_time-pycoqc.png "Actividad del canal en el tiempo")
+
+> <details-title>Otro perfil "Actividad del canal a lo largo del tiempo"</details-title>
+> 
+> En este ejemplo, casi todos los poros están activos a lo largo de la secuencia (perfil amarillo/rojo), lo que indica una secuencia excelente.
+> 
+> ![Channel activity over time good profile](../../images/quality-control/channel_activity_over_time-pycoqc-good.png)
+> 
+{: .details}
+
+
+> <comment-title>¡Pruébelo!</comment-title> Haga el control de calidad con **FastQC** {% icon tool %} y/o **Nanoplot** {% icon tool %} en `nanopore_basecalled-guppy.fastq.gz` y compare los resultados!
+> 
+{: .comment}
+
+# Conclusión
+
+
+En este tutorial comprobamos la calidad de los archivos FASTQ para asegurarnos de que sus datos tienen buen aspecto antes de inferir más información. Este paso es el primer paso habitual para análisis como RNA-Seq, ChIP-Seq, o cualquier otro análisis OMIC que dependa de datos NGS. Los pasos de control de calidad son similares para cualquier tipo de datos de secuenciación:
+
+- Evaluación de la calidad con herramientas como:
+  - *Lecturas cortas*: {% tool [FASTQE](toolshed.g2.bx.psu.edu/repos/iuc/fastqe/fastqe/0.3.1+galaxy0) %}
+  - *Corto+Largo*: {% tool [FASTQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0) %}
+  - *Lecturas largas*: {% tool [Nanoplot](toolshed.g2.bx.psu.edu/repos/iuc/nanoplot/nanoplot/1.41.0+galaxy0) %}
+  - *Sólo Nanopore*: {% tool [PycoQC](toolshed.g2.bx.psu.edu/repos/iuc/pycoqc/pycoqc/2.5.2+galaxy0) %}
+- Recorte y filtrado de **lecturas cortas** con una herramienta como **Cutadapt** {% icono herramienta %}
+

--- a/topics/sequence-analysis/tutorials/quality-control/it/tutorial.md
+++ b/topics/sequence-analysis/tutorials/quality-control/it/tutorial.md
@@ -1,0 +1,1112 @@
+---
+layout: tutorial_hands_on
+title: Controllo qualità
+zenodo_link: https://zenodo.org/records/61771
+questions:
+- How to perform quality control of NGS raw data?
+- What are the quality parameters to check for a dataset?
+- How to improve the quality of a dataset?
+objectives:
+- Assess short reads FASTQ quality using FASTQE 🧬😎 and FastQC
+- Assess long reads FASTQ quality using Nanoplot and PycoQC
+- Perform quality correction with Cutadapt (short reads)
+- Summarise quality metrics MultiQC
+- Process single-end and paired-end data
+follow_up_training:
+- type: internal
+  topic_name: sequence-analysis
+  tutorials:
+  - mapping
+time_estimation: 1H30M
+level: Introductory
+subtopic: basics
+key_points:
+- Perform quality control on every dataset before running any other bioinformatics
+  analysis
+- Assess the quality metrics and improve quality if necessary
+- Check the impact of the quality control
+- Different tools are available to provide additional quality metrics
+- For paired-end reads analyze the forward and reverse reads together
+contributions:
+  authorship:
+  - bebatut
+  - mblue9
+  - alexcorm
+  - abretaud
+  - lleroi
+  - r1corre
+  - stephanierobin
+  - neoformit
+  editing:
+  - Swathi266
+  funding:
+  - gallantries
+recordings:
+- youtube_id: coaMGvZazoc
+  length: 50M
+  speakers:
+  - LonsBio
+  captioners:
+  - LonsBio
+  date: '2023-05-19'
+- captioners:
+  - bebatut
+  - nagoue
+  - shiltemann
+  date: '2021-02-15'
+  galaxy_version: '21.01'
+  length: 1H10M
+  youtube_id: QJRlX2hWDKM
+  speakers:
+  - heylf
+- youtube_id: uiWZea53QIA
+  length: 51M
+  galaxy_version: 24.1.2.dev0
+  date: '2024-09-30'
+  speakers:
+  - dianichj
+  captioners:
+  - dianichj
+  bot-timestamp: 1727710795
+---
+
+
+
+
+Durante il sequenziamento, le basi nucleotidiche di un campione di DNA o RNA (libreria) vengono determinate dal sequenziatore. Per ogni frammento della libreria viene generata una sequenza, detta anche **lettura**, che è semplicemente una successione di nucleotidi.
+
+Le moderne tecnologie di sequenziamento possono generare un numero enorme di letture di sequenza in un singolo esperimento. Tuttavia, nessuna tecnologia di sequenziamento è perfetta e ogni strumento genera diversi tipi e quantità di errori, come la chiamata di nucleotidi errati. Queste basi chiamate in modo errato sono dovute alle limitazioni tecniche di ciascuna piattaforma di sequenziamento.
+
+Pertanto, è necessario comprendere, identificare ed escludere i tipi di errore che possono influire sull'interpretazione dell'analisi a valle. Il controllo della qualità delle sequenze è quindi un primo passo essenziale nell'analisi. Individuare tempestivamente gli errori consente di risparmiare tempo in seguito.
+
+> <agenda-title></agenda-title>
+> 
+> In questo tutorial ci occuperemo di:
+> 
+> 1. TOC {:toc}
+> 
+{: .agenda}
+
+# Ispezione di un file di sequenza grezzo
+
+> <hands-on-title>Caricamento dei dati</hands-on-title>
+> 
+> 1. Creare una nuova storia per questa esercitazione e darle un nome appropriato
+> 
+>    {% snippet faqs/galaxy/histories_create_new.md %}
+> 
+>    {% snippet faqs/galaxy/histories_rename.md %}
+> 
+> 2. Importare il file `female_oral2.fastq-4143.gz` da [Zenodo](https://zenodo.org/record/3977236) o dalla libreria di dati (chiedere al proprio istruttore) Questo è un campione di microbioma di un serpente {% cite StJacques2021 %}.
+> 
+>    ```
+>    https://zenodo.org/record/3977236/files/female_oral2.fastq-4143.gz
+>    ```
+> 
+>    {% snippet faqs/galaxy/datasets_import_via_link.md %}
+> 
+>    {% snippet faqs/galaxy/datasets_import_from_data_library.md %}
+> 
+> 3. Rinominare il dataset importato in `Reads`.
+> 
+{: .hands_on}
+
+Abbiamo appena importato un file in Galaxy. Questo file è simile ai dati che potremmo ottenere direttamente da un impianto di sequenziamento: un [file FASTQ](https://en.wikipedia.org/wiki/FASTQ_format).
+
+> <hands-on-title>Ispezione del file FASTQ</hands-on-title>
+> 
+> 1. Ispezionare il file facendo clic sull'icona {% icona galassia-occhio %} (occhio)
+> 
+{: .hands_on}
+
+Anche se sembra complicato (e forse lo è), il formato FASTQ è facile da capire con una piccola decodifica.
+
+Ogni lettura, che rappresenta un frammento della libreria, è codificata da 4 righe:
+
+| Line | Description                                                                                                                                                        |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1    | Always begins with `@` followed by the information about the read                                                                                                  |
+| 2    | The actual nucleic sequence                                                                                                                                        |
+| 3    | Always begins with a `+` and contains sometimes the same info in line 1                                                                                            |
+| 4    | Has a string of characters which represent the quality scores associated with each base of the nucleic sequence; must have the same number of characters as line 2 |
+
+Quindi, ad esempio, la prima sequenza nel nostro file è:
+
+```
+@M00970:337:000000000-BR5KF:1:1102:17745:1557 1:N:0:CGCAGAAC+ACAGAGTT
+GTGCCAGCCGCCGCGGTAGTCCGACGTGGCTGTCTCTTATACACATCTCCGAGCCCACGAGACCGAAGAACATCTCGTATGCCGTCTTCTGCTTGAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAGAAGCAAATGACGATTCAAGAAAGAAAAAAACACAGAATACTAACAATAAGTCATAAACATCATCAACATAAAAAAGGAAATACACTTACAACACATATCAATATCTAAAATAAATGATCAGCACACAACATGACGATTACCACACATGTGTACTACAAGTCAACTA
++
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGFGGGFGGGGGGAFFGGFGGGGGGGGFGGGGGGGGGGGGGGFGGG+38+35*311*6,,31=******441+++0+0++0+*1*2++2++0*+*2*02*/***1*+++0+0++38++00++++++++++0+0+2++*+*+*+*+*****+0**+0**+***+)*.***1**//*)***)/)*)))*)))*),)0(((-((((-.(4(,,))).,(())))))).)))))))-))-(
+```
+
+significa che il frammento denominato `@M00970` corrisponde alla sequenza di DNA `GTGCCAGCCGCCGCGGTAGTCCGACGTGGCTGTCTCTTATACACATCTCCGAGCCCACGAGACCGAAGAACATCTCGTATGCCGTCTTCTGCTTGAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAGAAGCAAATGACGATTCAAGAAAGAAAAAAACACAGAATACTAACAATAAGTCATAAACATCATCAACATAAAAAAGGAAATACACTTACAACACATATCAATATCTAAAATAAATGATCAGCACACAACATGACGATTACCACACATGTGTACTACAAGTCAACTA` e questa sequenza è stata sequenziata con una qualità `GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGFGGGFGGGGGGAFFGGFGGGGGGGGFGGGGGGGGGGGGGGFGGG+38+35*311*6,,31=******441+++0+0++0+*1*2++2++0*+*2*02*/***1*+++0+0++38++00++++++++++0+0+2++*+*+*+*+*****+0**+0**+***+)*.***1**//*)***)/)*)))*)))*),)0(((-((((-.(4(,,))).,(())))))).)))))))-))-(`.
+
+{% snippet topics/sequence-analysis/faqs/quality_score.md %}
+
+> <question-title></question-title>
+> 
+> 1. Quale carattere ASCII corrisponde al peggior punteggio Phred per Illumina 1.8+?
+> 2. Qual è il punteggio di qualità Phred del 3° nucleotide della prima sequenza?
+> 3. Come calcolare la precisione della base nucleotidica con il codice ASCII `/`?
+> 4. Qual è la precisione di questo terzo nucleotide?
+> 
+> > <solution-title></solution-title>
+> > 1. Il punteggio Phred peggiore è il più piccolo, quindi 0. Per Illumina 1.8+, corrisponde al carattere `!`.
+> > 2. Il terzo nucleotide della prima sequenza ha un carattere ASCII `G`, che corrisponde a un punteggio di 38.
+> > 3. può essere calcolato come segue:
+> >    - il codice ASCII per `/` è 47
+> >    - Punteggio di qualità = 47-33=14
+> >    - Formula per trovare la probabilità di errore: \\(P = 10^{-Q/10}})
+> >    - Probabilità di errore = \\\(10^{-14/10}\) = 0,03981
+> >    - Quindi Accuratezza = 100 - 0,03981 = 99,96%
+> > 4. Il nucleotide corrispondente `G` ha un'accuratezza di quasi il 99,96%
+> > 
+> {: .solution }
+> 
+{: .question}
+
+> <comment-title></comment-title> L'attuale lllumina (1.8+) utilizza il formato Sanger (Phred+33). Se si lavora con set di dati più vecchi, si possono incontrare i vecchi schemi di punteggio. **FastQC** {% icon tool %}, uno strumento che useremo più avanti in questo tutorial, può essere usato per cercare di determinare quale tipo di codifica di qualità viene usata (valutando la gamma di valori Phred visti nel FASTQ).
+> 
+{: .comment}
+
+Guardando il file in Galaxy, sembra che la maggior parte dei nucleotidi abbia un punteggio elevato (`G` corrisponde a un punteggio 38). È vero per tutte le sequenze? E per tutta la lunghezza della sequenza?
+
+
+# Valutazione della qualità con FASTQE 🧬😎 - solo letture brevi
+
+Per dare un'occhiata alla qualità della sequenza lungo tutte le sequenze, possiamo usare [FASTQE](https://fastqe.com/). Si tratta di uno strumento open-source che offre un modo semplice e divertente per controllare la qualità dei dati di sequenza grezzi e stamparli come emoji. È possibile utilizzarlo per dare una rapida impressione se i dati presentano problemi di cui si dovrebbe essere consapevoli prima di effettuare ulteriori analisi.
+
+> <hands-on-title>Controllo della qualità</hands-on-title>
+> 
+> 1. {% tool [FASTQE](toolshed.g2.bx.psu.edu/repos/iuc/fastqe/fastqe/0.3.1+galaxy0) %} con i seguenti parametri
+>    - {% icon param-files %} *"Dati FastQ "*: `Reads`
+>    - {% icon param-select %} *"Tipi di punteggio da mostrare "*: `Mean`
+> 
+> 2. Ispezione del file HTML generato
+> 
+{: .hands_on}
+
+Invece di esaminare i punteggi di qualità per ogni singola lettura, FASTQE esamina la qualità collettivamente per tutte le letture di un campione e può calcolare la media per ogni posizione nucleotidica lungo la lunghezza delle letture. Di seguito sono riportati i valori medi per questo set di dati.
+
+![FASTQE before](../../images/quality-control/fastqe-mean-before.png "FASTQE mean scores")
+
+è possibile vedere il punteggio per ogni [emoji nella documentazione di fastqe](https://github.com/fastqe/fastqe#scale). Le emoji sottostanti, con punteggi Phred inferiori a 20, sono quelle che speriamo di non vedere molto.
+
+| Phred Quality Score | ASCII code | Emoji |
+| ------------------- | ---------- | ----- |
+| 0                   | !          | 🚫     |
+| 1                   | "          | ❌     |
+| 2                   | #          | 👺     |
+| 3                   | $          | 💔     |
+| 4                   | %          | 🙅     |
+| 5                   | &          | 👾     |
+| 6                   | '          | 👿     |
+| 7                   | (          | 💀     |
+| 8                   | )          | 👻     |
+| 9                   | *          | 🙈     |
+| 10                  | +          | 🙉     |
+| 11                  | ,          | 🙊     |
+| 12                  | -          | 🐵     |
+| 13                  | .          | 😿     |
+| 14                  | /          | 😾     |
+| 15                  | 0          | 🙀     |
+| 16                  | 1          | 💣     |
+| 17                  | 2          | 🔥     |
+| 18                  | 3          | 😡     |
+| 19                  | 4          | 💩     |
+
+
+> <question-title></question-title>
+> 
+> Qual è il punteggio medio più basso in questo set di dati?
+> 
+> > <solution-title></solution-title> Il punteggio più basso di questo set di dati è 😿 13.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+
+# Valutazione della qualità con FastQC - letture corte e lunghe
+
+Un modo aggiuntivo o alternativo per verificare la qualità della sequenza è [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/). Fornisce una serie modulare di analisi che possono essere utilizzate per verificare se i dati presentano problemi di cui si dovrebbe essere a conoscenza prima di effettuare ulteriori analisi. Possiamo usarlo, ad esempio, per valutare se nei dati sono presenti adattatori noti. Lo eseguiamo sul file FASTQ.
+
+> <hands-on-title>Controllo della qualità</hands-on-title>
+> 
+> 1. {% tool [FASTQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0) %} con i seguenti parametri
+>    - {% icon param-files %} *"Dati di lettura grezzi dalla vostra storia attuale "*: `Reads`
+> 
+> 2. ispezionare il file HTML generato
+> 
+{: .hands_on}
+
+> <question-title></question-title>
+> 
+> Quale codifica Phred è utilizzata nel file FASTQ per queste sequenze?
+> 
+> > <solution-title></solution-title> I punteggi Phred sono codificati con `Sanger / Illumina 1.9` (`Encoding` nella tabella superiore).
+> > 
+> {: .solution }
+> 
+{: .question}
+
+## Qualità della sequenza per base
+
+Con FastQC possiamo usare il grafico della qualità della sequenza per base per controllare la qualità delle basi delle letture, in modo simile a quanto fatto con FASTQE.
+
+![Qualità della sequenza per base](../../images/quality-control/per_base_sequence_quality-before.png "Qualità della sequenza per base")
+
+sull'asse delle ascisse sono indicate le posizioni delle basi nella lettura. In questo esempio, il campione contiene letture lunghe fino a 296 bp.
+
+> <details-title>Asse x non uniforme</details-title>
+> 
+> L'asse x non è sempre uniforme. Quando si hanno letture lunghe, si applica un certo binning per mantenere le cose compatte. Lo vediamo nel nostro campione. Inizia con singole basi da 1 a 10. Successivamente, le basi vengono suddivise in una finestra larga un certo numero di basi. Il binning dei dati significa raggruppamento ed è una tecnica di pre-elaborazione dei dati utilizzata per ridurre gli effetti di piccoli errori di osservazione. Il numero di posizioni di base raggruppate dipende dalla lunghezza della lettura. Nel caso di letture >50bp, l'ultima parte del grafico riporterà le statistiche aggregate per finestre di 5bp. Le letture più corte avranno finestre più piccole e quelle più lunghe più grandi. Il binning può essere rimosso durante l'esecuzione di FastQC impostando il parametro "Disable grouping of bases for reads >50bp" su Yes.
+> 
+{: .details}
+
+Per ogni posizione, viene disegnato un boxplot con:
+
+- il valore mediano, rappresentato dalla linea centrale rossa
+- l'intervallo interquartile (25-75%), rappresentato dal riquadro giallo
+- i valori del 10% e del 90% nei baffi superiori e inferiori
+- la qualità media, rappresentata dalla linea blu
+
+L'asse y mostra i punteggi di qualità. Più alto è il punteggio, migliore è la chiamata della base. Lo sfondo del grafico divide l'asse y in punteggi di qualità molto buoni (verde), punteggi di qualità ragionevole (arancione) e letture di qualità scadente (rosso).
+
+È normale, con tutti i sequenziatori Illumina, che il punteggio di qualità mediano inizi a essere più basso nelle prime 5-7 basi e poi aumenti. La qualità delle letture sulla maggior parte delle piattaforme diminuisce alla fine della lettura. Ciò è spesso dovuto al decadimento del segnale o alla sfasatura durante la corsa di sequenziamento. I recenti sviluppi della chimica applicata al sequenziamento hanno migliorato in parte questo aspetto, ma le letture sono ora più lunghe che mai.
+
+
+> <details-title>Decadimento e sfasamento del segnale</details-title>
+> 
+> - Decadimento del segnale
+> 
+> L'intensità del segnale fluorescente decade a ogni ciclo del processo di sequenziamento. A causa della degradazione dei fluorofori, una parte dei filamenti nel cluster non viene allungata. La proporzione del segnale emesso continua a diminuire a ogni ciclo, determinando una diminuzione dei punteggi di qualità all'estremità 3' della lettura.
+> 
+> - Sfasatura
+> 
+> Il segnale inizia a confondersi con l'aumentare del numero di cicli perché il cluster perde sincronia. Con l'avanzare dei cicli, alcuni filamenti presentano fallimenti casuali di nucleotidi da incorporare a causa di:
+> 
+>  - Rimozione incompleta dei terminatori e dei fluorofori in 3'
+>  - Incorporazione di nucleotidi senza terminatori efficaci in 3'
+> 
+> Questo comporta una diminuzione dei punteggi di qualità all'estremità 3' della lettura.
+> 
+{: .details}
+
+
+> <details-title>Altri profili di qualità di sequenza</details-title>
+> 
+> Questi sono alcuni profili di qualità per sequenza di basi che possono indicare problemi con il sequenziamento.
+> 
+> - Sovra-raggruppamento
+> 
+>   Le strutture di sequenziamento possono raggruppare eccessivamente le celle di flusso. Ciò comporta piccole distanze tra i cluster e una sovrapposizione dei segnali. Due cluster possono essere interpretati come un unico cluster con segnali fluorescenti misti che vengono rilevati, riducendo la purezza del segnale. Genera punteggi di qualità inferiori per l'intera lettura.
+> 
+> - Disaggregazione della strumentazione
+> 
+>   occasionalmente possono verificarsi alcuni problemi con gli strumenti di sequenziamento durante una corsa. Qualsiasi calo improvviso della qualità o un'alta percentuale di letture di bassa qualità in tutta la lettura potrebbe indicare un problema nella struttura. Alcuni esempi di tali problemi:
+> 
+>    - Raffica di collettori
+> 
+>      ![Manifold burst](../../images/quality-control/per_base_sequence_quality_manifold_burst.png)
+> 
+>    - perdita di cicli
+> 
+>      ![Perdita di cicli](../../images/quality-control/per_base_sequence_quality_cycle_loss.png)
+> 
+>    - fallimento della lettura 2
+> 
+>      ![Perdita di cicli](../../images/quality-control/per_base_sequence_quality_read2_failure.png)
+> 
+>   Con questi dati, è necessario contattare il centro di sequenziamento per discuterne. Spesso è necessario un nuovo sequenziamento (che, secondo la nostra esperienza, viene offerto dall'azienda).
+> 
+{: .details}
+
+> <question-title></question-title>
+> 
+> 1. Come cambia il punteggio medio di qualità lungo la sequenza?
+> 2. Questa tendenza si riscontra in tutte le sequenze?
+> 
+> > <solution-title></solution-title>
+> > 1. Il punteggio medio di qualità (linea blu) scende circa a metà di queste sequenze. È normale che la qualità media diminuisca verso la fine delle sequenze, poiché i sequenziatori incorporano più nucleotidi errati alla fine. Tuttavia, in questo campione c'è un calo di qualità molto forte dalla metà in poi.
+> > 2. I box plot si allargano a partire dalla posizione ~100. Ciò significa che molte sequenze hanno un punteggio in calo a partire dalla metà della sequenza. Dopo 100 nucleotidi, oltre il 10% delle sequenze ha un punteggio inferiore a 20.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+Quando la qualità mediana è inferiore a un punteggio Phred di ~20, dovremmo considerare la possibilità di tagliare le basi di cattiva qualità dalla sequenza. Questo processo verrà spiegato nella sezione Trim e filtro.
+
+### Contenuto adattatore
+
+![Contenuto adattatore](../../images/quality-control/adapter_content-before.png "Contenuto adattatore")
+
+Il grafico mostra la percentuale cumulativa di letture con le diverse sequenze di adattatori in ogni posizione. Una volta che una sequenza di adattatori viene rilevata in una lettura, viene contata come presente fino alla fine della lettura, quindi la percentuale aumenta con la lunghezza della lettura. FastQC è in grado di rilevare alcuni adattatori per impostazione predefinita (ad es. Illumina, Nextera), mentre per altri è possibile fornire un file di contaminanti come input allo strumento FastQC.
+
+Idealmente i dati di sequenza Illumina non dovrebbero avere alcuna sequenza adattatore presente. Tuttavia, in caso di letture lunghe, alcuni inserti della libreria sono più corti della lunghezza della lettura, con conseguente passaggio all'adattatore all'estremità 3' della lettura. Questo campione di microbioma ha letture relativamente lunghe e possiamo vedere che è stato rilevato l'adattatore Nextera.
+
+> <details-title>Altri profili di contenuto dell'adattatore</details-title>
+> 
+> Il contenuto di adattatori può essere rilevato anche con le librerie RNA-Seq, dove la distribuzione delle dimensioni degli inserti della libreria è varia e probabilmente include alcuni inserti corti.
+> 
+> ![Contenuto adattatore](../../images/quality-control/adapter_content_rna_seq.png)
+> 
+{: .details}
+
+Per rimuovere l'adattatore, è possibile utilizzare uno strumento di trimming come Cutadapt. Il processo verrà illustrato nella sezione Filtro e trim.
+
+
+> <tip-title>Scorciatoia</tip-title>
+> 
+> Le sezioni seguenti illustrano in dettaglio alcuni degli altri grafici generati da FastQC. Si noti che alcuni grafici/moduli possono dare degli avvertimenti, ma sono normali per il tipo di dati con cui si sta lavorando, come discusso di seguito e [nelle FAQ di FASTQC](https://rtsf.natsci.msu.edu/genomics/tech-notes/fastqc-tutorial-and-faq/). Gli altri grafici ci forniscono informazioni per comprendere più a fondo la qualità dei dati e per vedere se è possibile apportare modifiche in laboratorio per ottenere dati di qualità superiore in futuro. Queste sezioni sono **opzionali** e se si desidera saltarle è possibile:
+>   - Passate direttamente alla [sezione successiva] (#trim-and-filter---short-reads) per imparare a tagliare i dati paired-end
+> 
+{: .tip}
+
+### Qualità della sequenza per mattonella
+
+Questo grafico consente di esaminare i punteggi di qualità di ciascuna piastrella su tutte le basi per vedere se c'è stata una perdita di qualità associata a una sola parte della cella di flusso. Il grafico mostra la deviazione dalla qualità media per ogni piastrella della flowcell. I colori più caldi indicano che le letture in quella determinata piastrella hanno una qualità peggiore per quella posizione rispetto alle letture in altre piastrelle. Con questo campione, si può notare che alcune piastrelle mostrano una qualità costantemente scarsa, soprattutto a partire da ~100bp. Un buon grafico dovrebbe essere tutto blu.
+
+![Qualità della sequenza per tile](../../images/quality-control/per_tile_sequence_quality-before.png "Qualità della sequenza per tile")
+
+Questo grafico appare solo per le librerie Illumina che conservano gli identificatori di sequenza originali. In essi è codificata la piastrella della cella di flusso da cui proviene ogni lettura.
+
+> <details-title>Altri profili di qualità delle piastrelle</details-title>
+> 
+> In alcuni casi, le sostanze chimiche utilizzate durante il sequenziamento si esauriscono con il passare del tempo e le ultime piastrelle ricevono le sostanze chimiche peggiori, rendendo le reazioni di sequenziamento un po' soggette a errori. Il grafico "Qualità della sequenza per tile" presenta quindi alcune linee orizzontali come questa:
+> 
+> ![Qualità della sequenza per tile con linee orizzontali](../../images/quality-control/per_tile_sequence_quality_horizontal_lines.png)
+> 
+{: .details}
+
+## Punteggi di qualità per sequenza
+
+Traccia il punteggio medio di qualità sull'intera lunghezza di tutte le letture sull'asse delle ascisse e fornisce il numero totale di letture con questo punteggio sull'asse delle ordinate:
+
+![Punteggi di qualità per sequenza](../../images/quality-control/per_sequence_quality_scores-before.png "Punteggi di qualità per sequenza")
+
+La distribuzione della qualità media delle letture dovrebbe avere un picco stretto nell'intervallo superiore del grafico. Può anche segnalare se un sottoinsieme di sequenze ha valori di qualità universalmente bassi: ciò può accadere perché alcune sequenze sono scarsamente rappresentate (ai margini del campo visivo ecc.), tuttavia queste dovrebbero rappresentare solo una piccola percentuale delle sequenze totali.
+
+## Contenuto della sequenza per base
+
+![Contenuto di sequenza per base](../../images/quality-control/per_base_sequence_content-before.png "Contenuto di sequenza per base per una libreria di DNA")
+
+"Per Base Sequence Content" traccia la percentuale di ciascuno dei quattro nucleotidi (T, C, A, G) in ciascuna posizione in tutte le letture del file di sequenza di input. Come per la qualità della sequenza per base, l'asse x è non uniforme.
+
+In una libreria casuale ci si aspetterebbe una differenza minima o nulla tra le quattro basi. La proporzione di ciascuna delle quattro basi dovrebbe rimanere relativamente costante per tutta la lunghezza della lettura con `%A=%T` e `%G=%C`, e le linee in questo grafico dovrebbero essere parallele tra loro. Si tratta di dati di ampliconi, in cui il DNA 16S viene amplificato con la PCR e sequenziato, quindi ci aspettiamo che questo grafico abbia qualche distorsione e non mostri una distribuzione casuale.
+
+> <details-title>Biasi per tipo di biblioteca</details-title>
+> 
+> Vale la pena notare che alcuni tipi di librerie produrranno sempre una composizione di sequenza distorta, normalmente all'inizio della lettura. Le librerie prodotte mediante priming con esameri casuali (comprese quasi tutte le librerie RNA-Seq) e quelle frammentate mediante trasposasi conterranno un bias intrinseco nelle posizioni di inizio delle letture (le prime 10-12 basi). Questo bias non coinvolge una sequenza specifica, ma fornisce invece un arricchimento di un certo numero di K-mers diversi all'estremità 5' delle letture. Pur trattandosi di un vero e proprio bias tecnico, non è qualcosa che può essere corretto con il trimming e nella maggior parte dei casi non sembra influire negativamente sull'analisi a valle. Tuttavia, produrrà un avviso o un errore in questo modulo.
+> 
+> ![Contenuto di sequenza per base per dati RNA-seq](../../images/quality-control/per_base_sequence_content_rnaseq.png)
+> 
+> Anche i dati ChIP-seq possono presentare distorsioni della sequenza di inizio lettura in questo grafico se frammentati con trasposasi. Con i dati convertiti in bisolfito, ad esempio i dati HiC, ci si aspetta una separazione di G da C e A da T:
+> 
+> ![Contenuto di sequenza per base per dati al bisolfito](../../images/quality-control/per_base_sequence_content_bisulphite.png)
+> 
+> Alla fine, si nota uno spostamento complessivo nella composizione della sequenza. Se lo spostamento è correlato a una perdita di qualità del sequenziamento, si può sospettare che le miscele siano fatte con un bias di sequenza più uniforme rispetto alle librerie convertite con bisolfito. Il ritaglio delle sequenze ha risolto il problema, ma se non fosse stato fatto avrebbe avuto un effetto drammatico sulle chiamate di metilazione effettuate.
+> 
+{: .details}
+
+> <question-title></question-title>
+> 
+> Perché c'è un'avvertenza per i grafici del contenuto di sequenza per base?
+> 
+> > <solution-title></solution-title> All'inizio delle sequenze, il contenuto di sequenza per base non è molto buono e le percentuali non sono uguali, come ci si aspetta per i dati degli ampliconi 16S.
+> > 
+> > 
+> {: .solution }
+> 
+{: .question}
+
+
+## Contenuto di GC per sequenza
+
+![Contenuto GC per sequenza](../../images/quality-control/per_sequence_gc_content-before.png "Contenuto GC per sequenza")
+
+Questo grafico mostra il numero di letture rispetto alla percentuale di basi G e C per lettura. Viene confrontato con una distribuzione teorica che ipotizza un contenuto di GC uniforme per tutte le letture, previsto per il sequenziamento dell'intero genoma, dove il picco centrale corrisponde al contenuto complessivo di GC del genoma sottostante. Poiché il contenuto di GC del genoma non è noto, il contenuto modale di GC viene calcolato dai dati osservati e utilizzato per costruire una distribuzione di riferimento.
+
+Una distribuzione dalla forma insolita potrebbe indicare una libreria contaminata o un altro tipo di sottoinsieme distorto. Una distribuzione normale spostata indica un bias sistematico, indipendente dalla posizione delle basi. Se c'è un bias sistematico che crea una distribuzione normale spostata, il modulo non lo segnalerà come errore, poiché non sa quale dovrebbe essere il contenuto di GC del genoma.
+
+Ma ci sono anche altre situazioni in cui può verificarsi una distribuzione di forma insolita. Ad esempio, nel caso del sequenziamento dell'RNA può verificarsi una maggiore o minore distribuzione del contenuto medio di GC tra i trascritti, che fa sì che il grafico osservato sia più ampio o più stretto di una distribuzione normale ideale.
+
+> <question-title></question-title>
+> 
+> Perché i grafici del contenuto di GC per sequenza sono falliti?
+> 
+> > <solution-title></solution-title> Ci sono più picchi. Questo può essere indicativo di una contaminazione inaspettata, come ad esempio adattatori, rRNA o sequenze sovrarappresentate. Oppure può essere normale se si tratta di dati di ampliconi o di trascritti RNA-seq molto abbondanti.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+### Distribuzione della lunghezza delle sequenze
+
+Questo grafico mostra la distribuzione delle dimensioni dei frammenti nel file analizzato. In molti casi si otterrà un semplice grafico che mostra un picco di una sola dimensione, ma per i file FASTQ di lunghezza variabile mostrerà le quantità relative di ogni frammento di sequenza di dimensioni diverse. Il nostro grafico mostra una lunghezza variabile mentre tagliamo i dati. Il picco più grande è a 296 bp, ma c'è un secondo grande picco a ~100 bp. Quindi, anche se le nostre sequenze hanno una lunghezza massima di 296 bp, molte sequenze di buona qualità sono più corte. Ciò corrisponde al calo della qualità delle sequenze a ~100 bp e alle strisce rosse che iniziano in questa posizione nel grafico della qualità delle sequenze per tile.
+
+![Distribuzione della lunghezza di sequenza](../../images/quality-control/sequence_length_distribution-before.png "Distribuzione della lunghezza di sequenza")
+
+Alcuni sequenziatori ad alta produttività generano frammenti di sequenza di lunghezza uniforme, ma altri possono contenere letture di lunghezza molto variabile. Anche all'interno di librerie di lunghezza uniforme, alcune pipeline tagliano le sequenze per rimuovere le chiamate di base di scarsa qualità dalla fine o dalle prime $$n$ basi se corrispondono alle prime $$n$ basi dell'adattatore fino al 90% (per impostazione predefinita), con talvolta $$n = 1$$.
+
+## Livelli di duplicazione delle sequenze
+
+Il grafico mostra in blu la percentuale di letture di una determinata sequenza nel file che sono presenti un determinato numero di volte nel file:
+
+![Livelli di duplicazione della sequenza](../../images/quality-control/sequence_duplication_levels-before.png "Livelli di duplicazione della sequenza")
+
+In una libreria eterogenea, la maggior parte delle sequenze si presenta una sola volta nell'insieme finale. Un basso livello di duplicazione può indicare un livello molto alto di copertura della sequenza target, ma un alto livello di duplicazione è più probabile che indichi un qualche tipo di bias di arricchimento.
+
+Si possono trovare due fonti di letture duplicate:
+- duplicazione PCR in cui i frammenti della libreria sono stati sovrarappresentati a causa di un arricchimento PCR distorto
+
+  È un problema perché i duplicati della PCR rappresentano male la vera proporzione di sequenze in ingresso.
+
+- Sequenze veramente sovrarappresentate, come trascritti molto abbondanti in una libreria RNA-Seq o in dati di ampliconi (come questo campione)
+
+  è un caso atteso e non preoccupante perché rappresenta fedelmente l'input.
+
+> <details-title>Maggiori dettagli sulla duplicazione</details-title>
+> 
+> FastQC conta il grado di duplicazione per ogni sequenza in una libreria e crea un grafico che mostra il numero relativo di sequenze con diversi gradi di duplicazione. Il grafico presenta due linee:
+> - Linea blu: distribuzione dei livelli di duplicazione per l'intero set di sequenze
+> - Linea rossa: distribuzione delle sequenze de-duplicate con le proporzioni del set deduplicato che provengono da diversi livelli di duplicazione nei dati originali.
+> 
+> Per i dati shotgun dell'intero genoma si prevede che quasi il 100% delle letture sia unico (appare solo una volta nei dati di sequenza). La maggior parte delle sequenze dovrebbe cadere all'estrema sinistra del grafico, sia nella linea rossa che in quella blu. Ciò indica una libreria altamente diversificata che non è stata sovra-sequenziata. Se la profondità di sequenziamento è estremamente elevata (ad esempio > 100 volte la dimensione del genoma) possono comparire alcune inevitabili duplicazioni di sequenze: in teoria esiste solo un numero finito di letture di sequenza completamente uniche che possono essere ottenute da un dato campione di DNA in ingresso.
+> 
+> arricchimenti più specifici di sottoinsiemi o la presenza di contaminanti a bassa complessità tenderanno a produrre picchi verso la destra del grafico. Questi picchi di duplicazione elevati appaiono spesso nella traccia blu, poiché costituiscono un'alta percentuale della libreria originale, ma di solito scompaiono nella traccia rossa, poiché costituiscono una percentuale insignificante dell'insieme deduplicato. Se i picchi persistono nella traccia rossa, ciò suggerisce la presenza di un gran numero di sequenze diverse altamente duplicate, che potrebbero indicare un set contaminante o una duplicazione tecnica molto grave.
+> 
+> Di solito nel sequenziamento dell'RNA ci sono trascritti molto abbondanti e altri poco abbondanti. Si prevede che per i trascritti ad alta abbondanza si osservino letture duplicate:
+> 
+> ![Livelli di duplicazione delle sequenze per RNA-seq](../../images/quality-control/sequence_duplication_levels_rna_seq.png)
+> 
+{: .details}
+
+## Sequenze sovrarappresentate
+
+Una normale libreria high-throughput conterrà un insieme eterogeneo di sequenze, senza che nessuna singola sequenza costituisca una frazione minima dell'insieme. Se si scopre che una singola sequenza è molto sovrarappresentata nell'insieme, significa che è altamente significativa dal punto di vista biologico oppure che la libreria è contaminata o non è così diversificata come ci si aspetta.
+
+FastQC elenca tutte le sequenze che costituiscono più dello 0,1% del totale. Per ogni sequenza sovrarappresentata, FastQC cercherà corrispondenze in un database di contaminanti comuni e riporterà il miglior risultato trovato. Gli hit devono avere una lunghezza minima di 20 bp e non avere più di 1 mismatch. Trovare un riscontro non significa necessariamente che sia la fonte della contaminazione, ma può indicare la direzione giusta. Vale anche la pena di sottolineare che molte sequenze di adattatori sono molto simili tra loro, quindi è possibile che venga segnalato un risultato non tecnicamente corretto, ma con una sequenza molto simile alla corrispondenza effettiva.
+
+I dati di sequenziamento dell'RNA possono avere alcuni trascritti così abbondanti da essere registrati come sequenze sovrarappresentate. Con i dati di sequenziamento del DNA, nessuna singola sequenza dovrebbe essere presente con una frequenza sufficientemente alta da essere elencata, ma a volte possiamo vedere una piccola percentuale di letture di adattamento.
+
+> <question-title></question-title>
+> 
+> Come possiamo scoprire quali sono le sequenze sovrarappresentate?
+> 
+> > <solution-title></solution-title> Possiamo eseguire BLAST sulle sequenze sovrarappresentate per vedere quali sono. In questo caso, se prendiamo la sequenza top overrepresented
+> > ```
+> > >overrep_seq1
+> > GTGTCAGCCGCCGCGGTAGTCCGACGTGGCTGTCTCTTATACACATCTCC
+> > ```
+> > e usiamo [blastn](https://blast.ncbi.nlm.nih.gov/Blast.cgi) contro il database predefinito dei nucleotidi (nr/nt) non otteniamo alcun risultato. Ma se usiamo [VecScreen](https://www.ncbi.nlm.nih.gov/tools/vecscreen/) vediamo che si tratta dell'adattatore Nextera. ![VecScreen](../../images/quality-control/vecscreen-nextera.png "Adattatore Nextera")
+> > 
+> {: .solution }
+> 
+{: .question}
+
+
+> <details-title>Più dettagli su altri tracciati FastQC</details-title>
+> 
+> 
+> #### Contenuto per base N
+> 
+> ![Contenuto per base N](../../images/quality-control/per_base_n_content-before.png "Contenuto per base N")
+> 
+> Se un sequenziatore non è in grado di effettuare una chiamata di base con sufficiente sicurezza, scriverà un "N" invece di una chiamata di base convenzionale. Questo grafico mostra la percentuale di chiamate di base in ogni posizione o bin per cui è stato chiamato un N.
+> 
+> Non è insolito vedere una percentuale molto alta di N che compaiono in una sequenza, soprattutto verso la fine della sequenza. Ma questa curva non dovrebbe mai salire sensibilmente sopra lo zero. Se ciò accade, significa che si è verificato un problema durante il sequenziamento. Nell'esempio seguente, un errore ha fatto sì che lo strumento non sia stato in grado di chiamare una base per circa il 20% delle letture in posizione 29:
+> 
+> ![Contenuto N per base](../../images/quality-control/per_base_n_content_error.png)
+> 
+> 
+> #### Contenuto Kmer
+> 
+> Questo grafico non viene emesso per impostazione predefinita. Come indicato nel modulo dello strumento, se si desidera questo modulo è necessario abilitarlo utilizzando un sottomodulo personalizzato e un file di limiti. Con questo modulo, FastQC esegue un'analisi generica di tutte le sequenze nucleotidiche brevi di lunghezza k (kmer, con k = 7 per impostazione predefinita) a partire da ogni posizione lungo la lettura nella libreria per trovare quelle che non hanno una copertura uniforme per tutta la lunghezza delle letture. Ogni kmer deve essere rappresentato in modo uniforme lungo tutta la lunghezza della lettura.
+> 
+> FastQC riporterà l'elenco dei kmer che compaiono in posizioni specifiche con una frequenza maggiore del previsto. Ciò può essere dovuto a diverse fonti di bias nella libreria, tra cui la presenza di sequenze adattatore di lettura che si accumulano alla fine delle sequenze. La presenza di sequenze sovrarappresentate nella libreria (come i dimeri dell'adattatore) fa sì che il grafico dei kmer sia dominato dai kmer di queste sequenze. Eventuali kmer parziali dovuti ad altri bias interessanti possono essere quindi diluiti e non facilmente visibili.
+> 
+> L'esempio seguente proviene da una libreria DNA-Seq di alta qualità. I kmer distorti all'inizio della lettura sono probabilmente dovuti a un'efficienza di taglio del DNA leggermente dipendente dalla sequenza o al risultato di un priming casuale:
+> 
+> ![Contenuto Kmer](../../images/quality-control/kmer_content.png "Contenuto Kmer")
+> 
+> Questo modulo può essere molto difficile da interpretare. Il grafico del contenuto di adattatori e la tabella delle sequenze sovrarappresentate sono più facili da interpretare e possono fornire informazioni sufficienti senza bisogno di questo grafico. Le librerie RNA-seq possono avere kmer altamente rappresentati che derivano da sequenze altamente espresse. Per saperne di più su questo grafico, consultare la [FastQC Kmer Content documentation](http://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/11%20Kmer%20Content.html).
+> 
+{: .details}
+
+Abbiamo cercato di spiegare qui i diversi rapporti di FastQC e alcuni casi d'uso. Ulteriori informazioni su questo argomento e su alcuni problemi comuni di sequenziamento di nuova generazione sono disponibili su [QCFAIL.com](https://sequencing.qcfail.com/)
+
+> <details-title>Problema specifico per tipi di librerie alternativi</details-title>
+> 
+> #### Piccoli/micro RNA
+> 
+> Nelle librerie di RNA di piccole dimensioni, in genere abbiamo un insieme relativamente piccolo di sequenze uniche e brevi. Le librerie di piccoli RNA non vengono tosate in modo casuale prima di aggiungere gli adattatori di sequenziamento alle loro estremità: tutte le letture per classi specifiche di microRNA saranno identiche. Il risultato sarà:
+> 
+> - contenuto di sequenza per base estremamente distorto
+> - distribuzione estremamente stretta del contenuto di GC
+> - Livelli molto elevati di duplicazione della sequenza
+> - abbondanza di sequenze sovrarappresentate
+> - lettura negli adattatori
+> 
+> #### Amplicon
+> 
+> Le librerie di ampliconi sono preparate mediante amplificazione PCR di un bersaglio specifico. Ad esempio, la regione ipervariabile V4 del gene 16S rRNA batterico. Ci si aspetta che tutte le letture di questo tipo di libreria siano quasi identiche. Il risultato sarà:
+> 
+> - contenuto di sequenza per base estremamente distorto
+> - distribuzione estremamente stretta del contenuto di GC
+> - Livelli molto elevati di duplicazione della sequenza
+> - abbondanza di sequenze sovrarappresentate
+> 
+> #### Sequenziamento con bisolfito o metilazione
+> 
+> Con il sequenziamento con bisolfito o metilazione, la maggior parte delle basi di citosina (C) viene convertita in timina (T). Il risultato sarà:
+> 
+> - contenuto di sequenza per base distorto
+> - Contenuto di GC per sequenza distorto
+> 
+> #### Contaminazione del dimero adattatore
+> 
+> Qualsiasi tipo di libreria può contenere una piccolissima percentuale di frammenti dimer adattatore (cioè senza inserto). È più probabile che si trovino nelle librerie di ampliconi costruite interamente con la PCR (per la formazione di primer-dimeri PCR) che nelle librerie DNA-Seq o RNA-Seq costruite con la legatura dell'adattatore. Se una frazione sufficiente della libreria è costituita da dimeri di adattatori, ciò si noterà nel rapporto FastQC:
+> 
+> - calo della qualità della sequenza per base dopo la base 60
+> - possibile distribuzione bimodale dei punteggi di qualità per sequenza
+> - Modello distinto osservato nel contenuto di sequenza per basi fino alla base 60
+> - picco nel contenuto di GC per sequenza
+> - adattatore di corrispondenza delle sequenze sovrarappresentato
+> - contenuto di adattatori > 0% a partire dalla base 1
+> 
+{: .details}
+
+> <comment-title>Sequenze di cattiva qualità</comment-title> Se la qualità delle letture non è buona, dovremmo sempre verificare prima cosa c'è che non va e pensarci: potrebbe derivare dal tipo di sequenziamento o da ciò che abbiamo sequenziato (un'alta quantità di sequenze sovrarappresentate nei dati di trascrittomica, una percentuale distorta di basi nei dati HiC).
+> 
+> Potete anche chiedere informazioni al centro di sequenziamento, soprattutto se la qualità è davvero scadente: i trattamenti di qualità non possono risolvere tutto. Se vengono tagliate troppe basi di cattiva qualità, le letture corrispondenti vengono filtrate e si perdono.
+> 
+{: .comment}
+
+# Trim e filtro - letture corte
+
+La qualità diminuisce al centro di queste sequenze. Ciò potrebbe causare distorsioni nelle analisi a valle con questi nucleotidi potenzialmente chiamati in modo errato. Le sequenze devono essere trattate per ridurre le distorsioni nelle analisi a valle. Il ritaglio può contribuire ad aumentare il numero di letture che l'allineatore o l'assemblatore sono in grado di utilizzare con successo, riducendo il numero di letture non mappate o non assemblate. In generale, i trattamenti di qualità includono:
+
+1. Sequenze di ritaglio/taglio/mascheramento
+    - da regioni a basso punteggio di qualità
+    - inizio/fine sequenza
+    - rimozione degli adattatori
+2. Filtraggio delle sequenze
+    - con punteggio di qualità medio basso
+    - troppo corto
+    - con troppe basi ambigue (N)
+
+Per svolgere questo compito utilizzeremo [Cutadapt](https://cutadapt.readthedocs.io/en/stable/guide.html) {% cite marcel2011cutadapt %}, uno strumento che migliora la qualità della sequenza automatizzando il trimming degli adattatori e il controllo di qualità. Si tratta di:
+
+- Rifilatura delle basi di bassa qualità dalle estremità. Il trimming della qualità viene eseguito prima di qualsiasi trimming dell'adattatore. Impostiamo la soglia di qualità a 20, una soglia comunemente usata, per saperne di più [nelle Phred Score FAQ di GATK] (https://gatk.broadinstitute.org/hc/en-us/articles/360035531872-Phred-scaled-quality-scores).
+- Ritagliare l'adattatore con Cutadapt. Per questo è necessario fornire la sequenza dell'adattatore. In questo esempio, Nextera è l'adattatore rilevato. Possiamo trovare la sequenza dell'adattatore Nextera sul [sito web Illumina] (https://support.illumina.com/bulletins/2016/12/what-sequences-do-i-use-for-adapter-trimming.html) `CTGTCTCTTATACACATCT`. Taglieremo questa sequenza dall'estremità 3' delle letture.
+- filtrare le sequenze con lunghezza < 20 dopo il trimming
+
+> <hands-on-title>Miglioramento della qualità della sequenza</hands-on-title>
+> 
+> 1. {% tool [Cutadapt](toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.9+galaxy1) %} con i seguenti parametri
+>    - *"Letture single-end o paired-end? "*: ..`Single-end`..
+>       - {% icon param-file %} *"File FASTQ/A "*: `Reads` (set di dati di input)
+> 
+>         > <tip-title>File non selezionabile?</tip-title> Se il file FASTQ non può essere selezionato, si può controllare se il formato è FASTQ con valori di qualità scalati Sanger (`fastqsanger.gz`). È possibile modificare il tipo di dati facendo clic sul simbolo della matita.
+> > 
+>          {: .tip}
+> 
+>    - In *"Read 1 Adapters "*:
+>       - *"1: Adattatori 3' (finali) "*:
+>          - *"Fonte "*: `Enter custom sequence`
+>          - *"Sequenza adattatore 3' personalizzata "*: `CTGTCTCTTATACACATCT`
+>    - In *"Altre opzioni di ritaglio delle letture "*
+>       - *"Cutoff di qualità (R1) "*: `20`
+>    - In *"Opzioni di filtraggio della lettura "*
+>       - *"Lunghezza minima (R1) "*: `20`
+>    - {% icon param-select %} *"Output aggiuntivi da generare "*: `Report`
+> 
+> 2. Ispezionare il file txt generato (`Report`)
+> 
+>    > <question-title></question-title>
+>    > 
+>    > 1. Quale percentuale di letture contiene un adattatore?
+>    > 2. Quale percentuale di letture è stata tagliata a causa della cattiva qualità?
+>    > 3. Quale percentuale di letture è stata rimossa perché troppo corta?
+>    > 
+>    > > <solution-title></solution-title>
+>    > > 1. il 56,8% delle letture contiene l'adattatore (`Reads with adapters:`)
+>    > > 2. il 35,1% delle letture è stato tagliato a causa della cattiva qualità (`Quality-trimmed:`)
+>    > > 3. lo 0 % delle letture è stato rimosso perché troppo corto
+> > > 
+> > {: .solution }
+> > 
+> {: .question}
+> 
+{: .hands_on}
+
+
+> <details-title>Trimming con Cutadapt</details-title>
+> 
+> Uno dei maggiori vantaggi di Cutadapt rispetto ad altri strumenti di trimming (ad esempio TrimGalore!) è che dispone di una buona [documentazione](https://cutadapt.readthedocs.io) che spiega in dettaglio il funzionamento dello strumento.
+> 
+> L'algoritmo di taglio della qualità Cutadapt consiste in tre semplici passaggi:
+> 
+> 1. Sottrarre il valore di soglia scelto dal valore di qualità di ogni posizione
+> 2. Calcolo di una somma parziale di queste differenze dalla fine della sequenza a ogni posizione (finché la somma parziale è negativa)
+> 3. Taglio al valore minimo della somma parziale
+> 
+> Nell'esempio seguente, supponiamo che l'estremità 3' debba essere sottoposta a quality-trimming con una soglia di 10 e abbiamo i seguenti valori di qualità
+> 
+> ```
+> 42 40 26 27 8 7 11 4 2 3
+> ```
+> 
+> 1. sottrarre la soglia
+> 
+>     ```
+>     32 30 16 17 -2 -3 1 -6 -8 -7
+>     ```
+> 
+> 2. sommare i numeri, partendo dall'estremità 3' (somme parziali) e fermarsi prima se la somma è maggiore di zero
+> 
+>     ```
+>     (70) (38) 8 -8 -25 -23 -20, -21 -15 -7
+>     ```
+> 
+>    I numeri tra parentesi non sono calcolati (perché 8 è maggiore di zero), ma vengono mostrati per completezza.
+> 
+> 3. Scegliere la posizione del minimo (`-25`) come posizione di taglio
+> 
+> Pertanto, la lettura viene tagliata alle prime quattro basi, che presentano valori di qualità
+> 
+> ```
+> 42 40 26 27
+> ```
+> 
+> Si noti quindi che le posizioni con un valore di qualità maggiore della soglia scelta vengono rimosse anche se sono incorporate in regioni di qualità inferiore (la somma parziale è decrescente se i valori di qualità sono minori della soglia). Il vantaggio di questa procedura è che è robusta contro un piccolo numero di posizioni con una qualità superiore alla soglia.
+> 
+> 
+> Le alternative a questa procedura sono:
+> 
+> * Taglio dopo la prima posizione con qualità inferiore alla soglia
+> * Approccio a finestra scorrevole
+> 
+>   L'approccio a finestra scorrevole controlla che la qualità media di ogni finestra di sequenza di lunghezza specificata sia maggiore della soglia. Si noti che, a differenza dell'approccio di cutadapt, questo approccio ha un parametro in più e la robustezza dipende dalla lunghezza della finestra (in combinazione con la soglia di qualità). Entrambi gli approcci sono implementati in Trimmomatic.
+> 
+{: .details}
+
+
+Possiamo esaminare i nostri dati tagliati con FASTQE e/o FastQC.
+
+> <hands-on-title>Controllo della qualità dopo il trimming</hands-on-title>
+> 
+> 1. {% tool [FASTQE](toolshed.g2.bx.psu.edu/repos/iuc/fastqe/fastqe/0.3.1+galaxy0) %}: Eseguire nuovamente **FASTQE** con i seguenti parametri
+>    - {% icon param-files %} *"Dati FastQ "*: `Cutadapt Read 1 Output`
+>    - {% icon param-select %} *"Tipi di punteggio da mostrare "*: `Mean`
+> 
+> 2. Ispezionare il nuovo rapporto FASTQE
+> 
+>    > <question-title></question-title>
+>    > 
+>    > Confrontate l'output FASTQE con quello precedente prima del trimming. La qualità della sequenza è migliorata?
+>    > 
+>    > {% snippet faqs/galaxy/features_scratchbook.md %}
+>    > 
+>    > > <solution-title></solution-title> Sì, le emoji del punteggio di qualità hanno un aspetto migliore (più felice) ora.
+>    > > 
+>    > > ![FASTQE before](../../images/quality-control/fastqe-mean-before.png "Before trimming")
+>    > > 
+>    > > ![FASTQE after](../../images/quality-control/fastqe-mean-after.png "After trimming")
+>    > > 
+> > > 
+> > {: .solution }
+> > 
+> {: .question}
+> 
+{: .hands_on}
+
+Con FASTQE possiamo vedere che abbiamo migliorato la qualità delle basi nel dataset.
+
+Possiamo anche, o invece, controllare i dati a qualità controllata con FastQC.
+
+
+> <hands-on-title>Controllo della qualità dopo il trimming</hands-on-title>
+> 
+> 1. {% tool [FASTQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0) %} con i seguenti parametri
+>    - {% icon param-files %} *"Dati di lettura brevi dalla vostra storia attuale "*: `Cutadapt Read 1 Output`
+> 
+> 2. ispezionare il file HTML generato
+> 
+{: .hands_on}
+
+> <question-title></question-title>
+> 1. La qualità della sequenza per base sembra migliore?
+> 2. L'adattatore è sparito?
+> 
+> > <solution-title></solution-title>
+> > 1. Sì. La stragrande maggioranza delle basi ha un punteggio di qualità superiore a 20. ![Qualità della sequenza per base](../../images/quality-control/per_base_sequence_quality-after.png "Qualità della sequenza per base")
+> > 
+> > 2. Sì. Non è stato rilevato alcun adattatore. ![Contenuto adattatore](../../images/quality-control/adapter_content-after.png)
+> > 
+> {: .solution }
+> 
+{: .question}
+
+Con FastQC possiamo vedere che abbiamo migliorato la qualità delle basi nel dataset e rimosso l'adattatore.
+
+> <details-title>Altri tracciati FastQC dopo il trimming</details-title>
+> 
+> ![Qualità della sequenza per tile](../../images/quality-control/per_tile_sequence_quality-after.png) Abbiamo alcune strisce rosse perché abbiamo tagliato quelle regioni dalle letture.
+> 
+> ![Punteggi di qualità per sequenza](../../images/quality-control/per_sequence_quality_scores-after.png) Ora abbiamo un picco di alta qualità invece di uno di alta e uno di bassa qualità che avevamo in precedenza.
+> 
+> ![Contenuto della sequenza per base](../../images/quality-control/per_base_sequence_content-after.png) Non abbiamo una rappresentazione uguale delle basi come prima, poiché si tratta di dati ampliconici.
+> 
+> ![Contenuto GC per sequenza](../../images/quality-control/per_sequence_gc_content-after.png) Ora abbiamo un unico picco GC principale dovuto alla rimozione dell'adattatore.
+> 
+> ![Contenuto N per base](../../images/quality-control/per_base_n_content-after.png) Questo è lo stesso di prima in quanto non abbiamo N in queste letture.
+> 
+> ![Distribuzione della lunghezza della sequenza](../../images/quality-control/sequence_length_distribution-after.png) Ora abbiamo più picchi e una gamma di lunghezze, invece del singolo picco che avevamo prima del trimming quando tutte le sequenze erano della stessa lunghezza.
+> 
+> ![Livelli di duplicazione della sequenza](../../images/quality-control/sequence_duplication_levels-after.png)
+> > <question-title></question-title>
+> > 
+> > A cosa corrisponde la sequenza top sovrarappresentata `GTGTCAGCCGCCGCGGTAGTCCGACGTGG`?
+> > 
+> > > <solution-title></solution-title> Se prendiamo la sequenza top overrepresented
+> > > ```
+> > > >overrep_seq1_after
+> > > GTGTCAGCCGCCGCGGTAGTCCGACGTGG
+> > > ```
+> > > e usando [blastn](https://blast.ncbi.nlm.nih.gov/Blast.cgi) contro il database predefinito dei nucleotidi (nr/nt) vediamo che i risultati migliori riguardano i geni 16S rRNA. Ciò ha senso in quanto si tratta di dati di ampliconi 16S, in cui il gene 16S viene amplificato mediante PCR.
+> > > 
+> > {: .solution }
+> > 
+> {: .question}
+> 
+{: .details}
+
+
+# Elaborazione di set di dati multipli
+
+## Elaborazione dei dati paired-end
+
+Con il sequenziamento paired-end, i frammenti vengono sequenziati da entrambi i lati. Questo approccio dà luogo a due letture per frammento, con la prima lettura in orientamento in avanti e la seconda in orientamento inverso-complementare. Con questa tecnica, abbiamo il vantaggio di ottenere più informazioni su ciascun frammento di DNA rispetto alle letture sequenziate solo con il sequenziamento single-end:
+
+```
+    ------>                       [single-end]
+
+    ----------------------------- [fragment]
+
+    ------>               <------ [paired-end]
+```
+La distanza tra le due letture è nota e quindi è un'informazione aggiuntiva che può migliorare la mappatura delle letture.
+
+Il sequenziamento Paired-end genera 2 file FASTQ:
+- Un file con le sequenze corrispondenti all'orientamento **avanti** di tutti i frammenti
+- Un file con le sequenze corrispondenti all'orientamento **inverso** di tutti i frammenti
+
+Di solito riconosciamo questi due file che appartengono a un campione dal nome che ha lo stesso identificatore per le letture ma un'estensione diversa, ad esempio `sampleA_R1.fastq` per le letture in avanti e `sampleA_R2.fastq` per le letture inverse. Può anche essere `_f` o `_1` per le letture in avanti e `_r` o `_2` per le letture inverse.
+
+I dati analizzati nella fase precedente erano single-end, quindi importeremo un set di dati RNA-seq paired-end da utilizzare. Eseguiremo FastQC e aggregeremo i due rapporti con MultiQC {% cite ewels2016multiqc %}.
+
+> <hands-on-title>Valutazione della qualità delle letture paired-end</hands-on-title>
+> 
+> 1. Importare le letture paired-end `GSM461178_untreat_paired_subset_1.fastq` e `GSM461178_untreat_paired_subset_2.fastq` da [Zenodo](https://zenodo.org/record/61771) o dalla libreria di dati (chiedere al proprio istruttore)
+> 
+>    ```
+>    https://zenodo.org/record/61771/files/GSM461178_untreat_paired_subset_1.fastq
+>    https://zenodo.org/record/61771/files/GSM461178_untreat_paired_subset_2.fastq
+>    ```
+> 
+> 2. {% tool [FASTQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0) %} con entrambi i set di dati:
+>    - {% icon param-files %} *"Dati di lettura grezzi dalla vostra storia attuale "*: entrambi i set di dati caricati.
+> 
+>    {% snippet faqs/galaxy/tools_select_multiple_datasets.md %}
+> 
+> 3. {% tool [MultiQC](toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9+galaxy1) %} con i seguenti parametri per aggregare i rapporti FastQC delle letture sia forward che reverse
+>      - In *"Risultati "*
+>        - *"Quale strumento è stato usato per generare i log? "*: `FastQC`
+>        - In *"Output FastQC "*
+>           - *"Tipo di output FastQC? "*: `Raw data`
+>           - {% icon param-files %} *"Output FastQC "*: file `Raw data` (output di entrambi i **FastQC** {% icon tool %})
+> 
+> 4. Esaminare la pagina web prodotta da MultiQC.
+> 
+{: .hands_on}
+
+
+> <question-title></question-title>
+> 
+> 1. Cosa ne pensate della qualità delle sequenze?
+> 2. Cosa dobbiamo fare?
+> 
+> > <solution-title></solution-title>
+> > 
+> > 1. La qualità delle sequenze sembra peggiore per le letture inverse che per quelle in avanti:
+> >     - Punteggi di qualità per sequenza: distribuzione più a sinistra, cioè qualità media delle sequenze più bassa
+> >     - Qualità della sequenza per base: curva meno regolare e diminuzione più marcata alla fine con un valore medio inferiore al 28
+> >     - Contenuto della sequenza per base: bias più forte all'inizio e nessuna distinzione chiara tra gruppi C-G e A-T
+> > 
+> >    Gli altri indicatori (adattatori, livelli di duplicazione, ecc.) sono simili.
+> > 
+> > 2. Dovremmo tagliare la fine delle sequenze e filtrarle con **Cutadapt** {% icon tool %}
+> > 
+> {: .solution}
+> 
+{: .question}
+
+Con le letture paired-end i punteggi medi di qualità per le letture forward saranno quasi sempre più alti di quelli per le letture reverse.
+
+Dopo il trimming, le letture inverse saranno più corte a causa della loro qualità e saranno quindi eliminate durante la fase di filtraggio. Se una delle letture inverse viene rimossa, deve essere rimossa anche la corrispondente lettura in avanti. Altrimenti si otterrà un numero diverso di letture in entrambi i file e in ordine diverso, e l'ordine è importante per le fasi successive. Pertanto **è importante trattare le letture forward e reverse insieme per il trimming e il filtraggio**.
+
+> <hands-on-title>Migliorare la qualità dei dati paired-end</hands-on-title>
+> 1. {% tool [Cutadapt](toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.9+galaxy1) %} con i seguenti parametri
+>    - *"Letture single-end o paired-end? "*: ..`Paired-end`..
+>       - {% icon param-file %} *"File FASTQ/A #1"*: `GSM461178_untreat_paired_subset_1.fastq` (set di dati in ingresso)
+>       - {% icon param-file %} *"File FASTQ/A #2"*: `GSM461178_untreat_paired_subset_2.fastq` (set di dati in ingresso)
+> 
+>         L'ordine è importante!
+> 
+>       - In *adattatori di lettura 1* o *adattatori di lettura 2*
+> 
+>         Non sono stati trovati adattatori in questi set di dati. Quando si elaborano i propri dati e si sa quali sequenze di adattatori sono state utilizzate durante la preparazione della libreria, è necessario fornire le loro sequenze qui.
+> 
+>    - In *"Altre opzioni di ritaglio delle letture "*
+>       - *"Cutoff di qualità (R1) "*: `20`
+>    - In *"Opzioni di filtraggio della lettura "*
+>       - *"Lunghezza minima (R1) "*: `20`
+>    - {%icon param-select%} *"Output aggiuntivi da generare "*: `Report`
+> 
+> 2. Ispezionare il file txt generato (`Report`)
+> 
+>    > <question-title></question-title>
+>    > 
+>    > 1. Quante coppie di basi sono state rimosse dalle letture a causa della cattiva qualità?
+>    > 2. Quante coppie di sequenze sono state rimosse perché troppo corte?
+>    > 
+>    > > <solution-title></solution-title>
+>    > > 1. 44.164 bp (`Quality-trimmed:`) per le letture in avanti e 138.638 bp per le letture inverse.
+>    > > 2. 1.376 sequenze sono state rimosse perché almeno una lettura era più corta del limite di lunghezza (322 quando sono state analizzate solo le letture in avanti).
+> > > 
+> > {: .solution }
+> > 
+> {: .question}
+> 
+{: .hands_on}
+
+Oltre al rapporto, Cutadapt genera 2 file:
+- Lettura 1 con le letture in avanti tagliate e filtrate
+- Lettura 2 con le letture inverse rifilate e filtrate
+
+Questi set di dati possono essere utilizzati per l'analisi a valle, ad esempio la mappatura.
+
+> <question-title></question-title>
+> 
+> 1. Che tipo di allineamento si usa per trovare gli adattatori nelle letture?
+> 2. Qual è il criterio per scegliere il miglior allineamento di adattatori?
+> 
+> > <solution-title></solution-title>
+> > 
+> > 1. Allineamento semi-globale, cioè solo la parte sovrapposta della lettura e della sequenza adattatore viene utilizzata per il punteggio.
+> > 2. Viene calcolato un allineamento con la massima sovrapposizione che presenta il minor numero di mismatch e indel.
+> > 
+> {: .solution}
+> 
+{: .question}
+
+# Valutazione della qualità con Nanoplot - Solo letture lunghe
+
+In caso di letture lunghe, possiamo controllare la qualità della sequenza con [Nanoplot](https://github.com/wdecoster/NanoPlot/) ({% cite 10.1093/bioinformatics/bty149 %}). Fornisce statistiche di base con grafici gradevoli per una rapida panoramica del controllo di qualità.
+
+> <hands-on-title>Controllo della qualità di letture lunghe</hands-on-title>
+> 1. Creare una nuova cronologia per questa parte e darle un nome appropriato
+> 
+> 2. Importazione delle letture PacBio HiFi `m64011_190830_220126.Q20.subsample.fastq.gz` da [Zenodo](https://zenodo.org/record/5730295)
+> 
+>    ```
+>    https://zenodo.org/records/5730295/files/m64011_190830_220126.Q20.subsample.fastq.gz
+>    ```
+> 
+> 3. {% tool [Nanoplot](toolshed.g2.bx.psu.edu/repos/iuc/nanoplot/nanoplot/1.41.0+galaxy0) %} con i seguenti parametri
+>    - {% icon param-files %} *"file "*: `m64011_190830_220126.Q20.subsample.fastq.gz`
+>    - *"Opzioni per la personalizzazione delle trame create "*
+>        - {% icona param-select %} *"Specifica il formato bivariato dei grafici. "*: `dot`, `kde`
+>        - {% icon param-select %} *"Mostra il segno N50 nell'istogramma della lunghezza della lettura. "*: `Yes`
+> 
+> 4. Ispezione del file HTML generato
+> 
+{: .hands_on}
+
+> <question-title></question-title>
+> 
+> Qual è il Qscore medio?
+> 
+> > <solution-title></solution-title> Il Qscore si aggira intorno a Q32. Nel caso di PacBio CLR e Nanopore, è intorno a Q12 e vicino a Q31 per Illumina (NovaSeq 6000). ![Grafico del Qscore tra Illumina, PacBio e Nanopore](../../images/quality-control/qscore-illumina-pacbio-nanopore.png "Comparison of Qscore between Illumina, PacBio and Nanopore")
+> > 
+> > Definizione: Qscores è la probabilità media di errore per base, espressa sulla scala log (Phred)
+> > 
+> {: .solution }
+> 
+> Qual è la mediana, la media e l'N50?
+> > <solution-title></solution-title> La mediana, la lunghezza media delle letture e anche la N50 sono vicine a 18.000 bp. Per le letture PacBio HiFi, la maggior parte delle letture è generalmente vicina a questo valore poiché la preparazione della libreria include una fase di selezione delle dimensioni. Per altre tecnologie come PacBio CLR e Nanopore, il valore è maggiore e dipende principalmente dalla qualità dell'estrazione del DNA.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+## Istogramma delle lunghezze delle letture
+
+Questo grafico mostra la distribuzione delle dimensioni dei frammenti nel file analizzato. A differenza della maggior parte delle corse Illumina, le letture lunghe hanno una lunghezza variabile e questo mostra le quantità relative di ogni frammento di sequenza di dimensioni diverse. In questo esempio, la distribuzione della lunghezza delle letture è centrata vicino a 18kbp, ma i risultati possono essere molto diversi a seconda dell'esperimento.
+
+![Istogramma delle lunghezze di lettura](../../images/quality-control/HistogramReadlength.png "Istogramma delle lunghezze di lettura")
+
+## Grafico della lunghezza delle letture rispetto alla qualità media delle letture utilizzando i punti
+
+Questo grafico mostra la distribuzione delle dimensioni dei frammenti in base al Qscore del file analizzato. In generale, non esiste un legame tra la lunghezza delle letture e la loro qualità, ma questa rappresentazione consente di visualizzare entrambe le informazioni in un unico grafico e di individuare eventuali aberrazioni. Nelle corse con molte letture brevi, le letture più corte sono talvolta di qualità inferiore rispetto alle altre.
+
+![Grafico della lunghezza delle letture rispetto alla qualità media delle letture utilizzando i punti](../../images/quality-control/LengthvsQualityScatterPlot_dot.png "Istogramma della lunghezza delle letture")
+
+> <question-title></question-title> Guardando "Read lengths vs Average read quality plot using dots plot". Ha notato qualcosa di insolito nel Qscore? Può spiegarlo?
+> > <solution-title></solution-title> Non ci sono letture sotto Q20. La qualifica per le letture HiFi è:
+> > - un numero minimo di 3 subreads
+> > - Un Qscore di lettura >=20 ![PacBio HiFi sequencing](../../images/quality-control/pacbio-css-hifi-sequencing.png "PacBio HiFi sequencing")
+> > 
+> {: .solution }
+> 
+{: .question}
+
+> <comment-title>Prova! </comment-title> Esegui il controllo di qualità con **FastQC** {% icon tool %} su `m64011_190830_220126.Q20.subsample.fastq.gz` e confronta i risultati!
+> 
+{: .comment}
+
+# Valutazione della qualità con PycoQC - solo Nanopore
+
+[PycoQC](https://github.com/tleonardi/pycoQC) ({% cite Leger2019 %}) è uno strumento di visualizzazione dei dati e di controllo della qualità per i dati nanopore. A differenza di FastQC/Nanoplot, necessita di uno specifico file sequencing_summary.txt generato dai basecaller per nanopori di Oxford, come Guppy o il vecchio basecaller albacore.
+
+Uno dei punti di forza di PycoQC è che è interattivo e altamente personalizzabile, ad esempio, i grafici possono essere ritagliati, è possibile ingrandire e rimpicciolire, sotto-selezionare aree ed esportare figure.
+
+> <hands-on-title>Controllo della qualità delle letture Nanopore</hands-on-title>
+> 1. Creare una nuova cronologia per questa parte e darle un nome appropriato
+> 
+> 2. Importazione delle letture nanopore `nanopore_basecalled-guppy.fastq.gz` e `sequencing_summary.txt` da [Zenodo](https://zenodo.org/record/5730295)
+> 
+>    ```
+>    https://zenodo.org/records/5730295/files/nanopore_basecalled-guppy.fastq.gz
+>    https://zenodo.org/records/5730295/files/sequencing_summary.txt
+>    ```
+> 
+> 3. {% tool [PycoQC](toolshed.g2.bx.psu.edu/repos/iuc/pycoqc/pycoqc/2.5.2+galaxy0) %} con i seguenti parametri
+> 
+>    - {% icon param-files %} *"Un file sequencing_summary "*: `sequencing_summary.txt`
+> 
+> 4. Ispezione della pagina web prodotta da PycoQC
+> 
+{: .hands_on}
+
+> <question-title></question-title>
+> 
+> Quante letture avete in totale?
+> > <solution-title></solution-title> ~270k letture in totale (vedere la tabella di riepilogo Basecall, "Tutte le letture") Per la maggior parte dei profili di basecalling, Guppy assegnerà le letture come "Pass" se il Qscore della lettura è almeno pari a 7.
+> > 
+> {: .solution }
+> 
+> Qual è la lunghezza mediana, minima e massima delle letture, qual è l'N50?
+> > <solution-title></solution-title> La lunghezza mediana della lettura e l'N50 si possono trovare per tutte e per tutte le letture superate, cioè quelle che hanno superato le impostazioni di qualità di Guppy (Qscore >= 7), nella tabella riassuntiva della basecall. Per le lunghezze minime (195bp) e massime (256kbp) delle letture, si può trovare con il grafico delle lunghezze delle letture.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+## Lunghezza delle letture di base
+
+Come per FastQC e Nanoplot, questo grafico mostra la distribuzione delle dimensioni dei frammenti nel file analizzato. Come per PacBio CLR/HiFi, le letture lunghe hanno una lunghezza variabile e questo mostra le quantità relative di ogni frammento di sequenza di dimensioni diverse. In questo esempio, la distribuzione della lunghezza delle letture è piuttosto dispersa, con una lunghezza minima per le letture passate di circa 200 bp e una lunghezza massima di circa 150.000 bp.
+
+![Lunghezza delle letture richiamate](../../images/quality-control/basecalled_reads_length-pycoqc.png "Lunghezza delle letture richiamate")
+
+### Qualità PHRED delle letture in base
+
+Questo grafico mostra la distribuzione dei punteggi di qualità (Q) per ogni lettura. Questo punteggio mira a fornire un punteggio di qualità globale per ogni lettura. La definizione esatta di Qscores è: la probabilità media di errore per base, espressa sulla scala log (Phred). Nel caso dei dati Nanopore, la distribuzione è generalmente centrata intorno a 10 o 12. Per le vecchie corse, la distribuzione può essere più ampia. Per le vecchie corse, la distribuzione può essere più bassa, poiché i modelli di chiamata delle basi sono meno precisi dei modelli recenti.
+
+![Qualità PHRED delle letture richiamate](../../images/quality-control/basecalled_reads_PHRED_quality-pycoqc.png "Qualità PHRED delle letture richiamate")
+
+## Lunghezza delle letture chiamate in base vs qualità delle letture PHRED
+
+> <question-title></question-title> Come appaiono la qualità media e la distribuzione della qualità della corsa?
+> > <solution-title></solution-title> La maggior parte delle letture ha un Qscore compreso tra 8 e 11, che è standard per i dati Nanopore. Attenzione: per gli stessi dati, il basecaller utilizzato (Albacor, Guppy, Bonito), il modello (fast, hac, sup) e la versione dello strumento possono dare risultati diversi.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+Come per NanoPlot, questa rappresentazione fornisce una visualizzazione 2D del Qscore delle letture in base alla lunghezza.
+
+![Lunghezza delle letture richiamate vs qualità delle letture PHRED](../../images/quality-control/basecalled_reads_length_vs_reads_PHRED_quality-pycoqc.png "Lunghezza delle letture richiamate vs qualità delle letture PHRED")
+
+## Output nel tempo dell'esperimento
+
+Questa rappresentazione fornisce informazioni sulle letture sequenziate nel tempo per una singola corsa:
+
+- Ogni immagine indica un nuovo carico della cella a flusso (3 + il primo carico).
+- Il contributo in letture totali per ogni "rifornimento".
+- La produzione di letture diminuisce nel tempo:
+  - La maggior parte del materiale (DNA/RNA) viene sequenziato
+  - Saturazione dei pori
+  - Degradazione del materiale/dei pori
+  - ...
+
+In questo esempio, il contributo di ogni rifornimento è molto basso e si può considerare una cattiva corsa. L'area del grafico "Cummulativo" (blu chiaro) indica che il 50% di tutte le letture e quasi il 50% di tutte le basi sono state prodotte nelle prime 5 ore dell'esperimento di 25 ore. Sebbene sia normale che la resa diminuisca nel tempo, una diminuzione di questo tipo non è un buon segno.
+
+![Output over experiment time](../../images/quality-control/output_over_experiment_time-pycoqc.png "Output over experiment time")
+
+> <details-title>Altro profilo "Output nel tempo dell'esperimento"</details-title>
+> 
+> In questo esempio, la produzione di dati nel tempo è diminuita solo leggermente nel corso delle 12 ore, con un continuo aumento dei dati cumulativi. L'assenza di una curva decrescente alla fine della corsa indica che c'è ancora materiale biologico sulla cella a flusso. La corsa è terminata prima che tutto fosse sequenziato. Si tratta di una corsa eccellente, che può essere considerata addirittura eccezionale.
+> 
+> ![Profilo output over experiment time good](../../images/quality-control/output_over_experiment_time-pycoqc-good.png)
+> 
+{: .details}
+
+### Lunghezza delle letture nel tempo dell'esperimento
+
+> <question-title></question-title> La lunghezza della lettura è cambiata nel tempo? Quale potrebbe essere il motivo?
+> > <solution-title></solution-title> Nell'esempio attuale la lunghezza della lettura aumenta nel corso della corsa di sequenziamento. Una spiegazione è che la densità dell'adattatore è maggiore per molti frammenti corti e quindi la possibilità che un frammento più corto si attacchi a un poro è maggiore. Inoltre, le molecole più corte possono muoversi più velocemente sul chip. Con il passare del tempo, tuttavia, i frammenti più corti diventano più rari e quindi più frammenti lunghi si attaccano ai pori e vengono sequenziati.
+> > 
+> {: .solution }
+> 
+{: .question}
+
+La lunghezza della lettura nel tempo dell'esperimento dovrebbe essere stabile. Può aumentare leggermente nel corso del tempo, poiché i frammenti corti tendono a essere sovra-sequenziati all'inizio e sono meno presenti nel corso del tempo.
+
+![Read length over experiment time](../../images/quality-control/read_length_over_experiment_time-pycoqc.png "Read length over experiment time")
+
+## Attività del canale nel tempo
+
+fornisce una panoramica dei pori disponibili, dell'utilizzo dei pori durante l'esperimento, dei pori inattivi e mostra se il carico della cella a flusso è buono (quasi tutti i pori sono utilizzati). In questo caso, la stragrande maggioranza dei canali/pori sono inattivi (bianchi) durante la corsa di sequenziamento, quindi la corsa può essere considerata negativa.
+
+Si spera in un grafico che sia scuro vicino all'asse X e che con valori Y più alti (aumento del tempo) non diventi troppo chiaro/bianco. A seconda che si scelga "Letture" o "Basi" a sinistra, il colore indica il numero di basi o di letture per intervallo di tempo
+
+![Attività del canale nel tempo](../../images/quality-control/channel_activity_over_time-pycoqc.png "Attività del canale nel tempo")
+
+> <details-title>Altro profilo "Attività del canale nel tempo"</details-title>
+> 
+> In questo esempio, quasi tutti i pori sono attivi lungo tutta la corsa (profilo giallo/rosso), il che indica una corsa eccellente.
+> 
+> ![Attività del canale nel tempo profilo buono](../../images/quality-control/channel_activity_over_time-pycoqc-good.png)
+> 
+{: .details}
+
+
+> <comment-title>Prova! </comment-title> Esegui il controllo di qualità con **FastQC** {% icon tool %} e/o **Nanoplot** {% icon tool %} su `nanopore_basecalled-guppy.fastq.gz` e confronta i risultati!
+> 
+{: .comment}
+
+# Conclusione
+
+
+In questa esercitazione abbiamo controllato la qualità dei file FASTQ per assicurarci che i loro dati siano buoni prima di dedurre ulteriori informazioni. Questa fase è il primo passo abituale per analisi come RNA-Seq, ChIP-Seq o qualsiasi altra analisi OMIC basata su dati NGS. Le fasi del controllo di qualità sono simili per qualsiasi tipo di dati di sequenziamento:
+
+- Valutazione della qualità con strumenti come:
+  - *Letture brevi*: {% tool [FASTQE](toolshed.g2.bx.psu.edu/repos/iuc/fastqe/fastqe/0.3.1+galaxy0) %}
+  - *Corto+Lungo*: {% tool [FASTQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0) %}
+  - *Letture lunghe*: {% tool [Nanoplot](toolshed.g2.bx.psu.edu/repos/iuc/nanoplot/nanoplot/1.41.0+galaxy0) %}
+  - *Solo nanopore*: {% tool [PycoQC](toolshed.g2.bx.psu.edu/repos/iuc/pycoqc/pycoqc/2.5.2+galaxy0) %}
+- Taglio e filtraggio per **letture corte** con uno strumento come **Cutadapt** {% icon tool %}
+


### PR DESCRIPTION
This is really a placeholder PR for @unode to know where the translated content is.