### PR TITLE
Fixed typos on translated snippets

### DIFF
--- a/faqs/galaxy-es/collections_build_list_paired.md
+++ b/faqs/galaxy-es/collections_build_list_paired.md
@@ -11,7 +11,7 @@ contributors:
 
 
 
-* Haga clic en {% icono galaxy-selector %} **Seleccionar Items** en la parte superior del panel del historial ![Botón Seleccionar Items]({% link topics/galaxy-interface/images/historyItemControls.png %})
+* Haga clic en {% icon galaxy-selector %} **Seleccionar Items** en la parte superior del panel del historial ![Botón Seleccionar Items]({% link topics/galaxy-interface/images/historyItemControls.png %})
 * Marque {% if include.datasets_description %}{{{ include.datasets_description }}{% else %}todos los conjuntos de datos de su historial que desee incluir{% endif %}
 * Haga clic en **{% if include.n %}{{ include.n }}{% else %}n{% endif %} de N seleccionados** y elija **Crear lista de pares de conjuntos de datos**
 

--- a/faqs/galaxy-es/datasets_add_tag.md
+++ b/faqs/galaxy-es/datasets_add_tag.md
@@ -27,8 +27,8 @@ Los conjuntos de datos se pueden etiquetar. Esto simplifica el seguimiento de lo
 
 Se llaman **etiquetas de nombre**. La característica única de estas etiquetas es que se *propagan*: si un conjunto de datos se etiqueta con una etiqueta de nombre, todos los derivados (hijos) de este conjunto de datos heredarán automáticamente esta etiqueta (véase más abajo). La figura siguiente explica por qué es tan útil. Considere el siguiente análisis (los números entre paréntesis corresponden a los números de los conjuntos de datos en la siguiente figura):
 
-1. un conjunto de lecturas hacia adelante y hacia atrás (conjuntos de datos 1 y 2) se mapea contra una referencia usando {% herramienta Bowtie2 %} generando el conjunto de datos 3;
-1. dataset 3 se utiliza para calcular la cobertura de lectura utilizando {% herramienta BedTools Genome Coverage %} *por separado* para las cadenas `+` y `-`. Esto genera dos conjuntos de datos (4 y 5 para más y menos, respectivamente);
+1. un conjunto de lecturas hacia adelante y hacia atrás (conjuntos de datos 1 y 2) se mapea contra una referencia usando {% tool Bowtie2 %} generando el conjunto de datos 3;
+1. dataset 3 se utiliza para calcular la cobertura de lectura utilizando {% tool BedTools Genome Coverage %} *por separado* para las cadenas `+` y `-`. Esto genera dos conjuntos de datos (4 y 5 para más y menos, respectivamente);
 1. los conjuntos de datos 4 y 5 se utilizan como entrada para los conjuntos de datos {% tool Macs2 broadCall %} que generan los conjuntos de datos 6 y 8;
 1. los conjuntos de datos 6 y 8 son intersecados con las coordenadas de los genes (conjunto de datos 9) usando {% tool BedTools Intersect %} generando los conjuntos de datos 10 y 11.
 

--- a/faqs/galaxy-es/datasets_create_new_file.md
+++ b/faqs/galaxy-es/datasets_create_new_file.md
@@ -25,12 +25,12 @@ examples:
 ---
 
 
-* Pulse {% icono galaxy-upload %} **Cargar Datos** en la parte superior del panel de herramientas
+* Pulse {% icon galaxy-upload %} **Cargar Datos** en la parte superior del panel de herramientas
 * Seleccione {% icon galaxy-wf-edit %} **Pegar/Obtener Datos** en la parte inferior
 * Pegue el contenido del archivo en el campo de texto {% if include.name %}
 * Cambie el nombre del conjunto de datos de "New File" a `{{ include.name }}` {% endif %} {%- if include.format -%}
 * Cambie **Type** de "Auto-detect" a `{{ include.format }}` {%- endif -%} {%- if include.genome -%}
 * Cambiar **Genome** a `{{ include.genome }}` {%- endif -%} {%- if include.convertspaces -%}
-* En el menú Configuración ({% icono galaxy-gear %}) seleccione **Convertir espacios en tabuladores** {%- endif -%}
+* En el menú Configuración ({% icon galaxy-gear %}) seleccione **Convertir espacios en tabuladores** {%- endif -%}
 * Pulse **Iniciar** y **Cerrar** la ventana
 

--- a/faqs/galaxy-es/datasets_rename.md
+++ b/faqs/galaxy-es/datasets_rename.md
@@ -18,7 +18,7 @@ examples:
 ---
 
 
-- Haga clic en el {% icono galaxy-pencil %} **icono lápiz** del conjunto de datos para editar sus atributos
+- Haga clic en el {% icon galaxy-pencil %} **icono lápiz** del conjunto de datos para editar sus atributos
 - En el panel central, cambie el campo **Name** {% if include.name %} a `{{ include.name }}` {% endif %}
 - Haga clic en el botón **Guardar**
 

--- a/faqs/galaxy-es/histories_copy_dataset.md
+++ b/faqs/galaxy-es/histories_copy_dataset.md
@@ -18,7 +18,7 @@ Hay 3 formas de copiar conjuntos de datos entre historiales
 
 1. Del historial original
 
-    1. Haga clic en el icono {% icono galaxy-gear %} que se encuentra en la parte superior de la lista de conjuntos de datos en el panel de historial
+    1. Haga clic en el icono {% icon galaxy-gear %} que se encuentra en la parte superior de la lista de conjuntos de datos en el panel de historial
     2. Haga clic en **Copiar conjuntos de datos**
     3. Seleccione los archivos deseados {% if include.history_name %}
     4. "Nuevo historial llamado:" `{{ include.history_name }}` {% else %}
@@ -26,10 +26,10 @@ Hay 3 formas de copiar conjuntos de datos entre historiales
     5. Validar por 'Copiar elementos del historial'
     5. Haga clic en el nombre de la nueva historia en el cuadro verde que acaba de aparecer para cambiar a esta historia
 
-2. Uso del {% icono galaxy-columns %} **Mostrar Historias lado a lado**
+2. Uso del {% icon galaxy-columns %} **Mostrar Historias lado a lado**
 
-    1. Haga clic en la flecha desplegable {% icono galaxia-desplegable %} arriba a la derecha del panel de historial (**Opciones de historial**)
-    2. Haga clic en {% icono galaxia-columnas %} **Mostrar Historias lado a lado**
+    1. Haga clic en la flecha desplegable {% icon galaxy-dropdown %} arriba a la derecha del panel de historial (**Opciones de historial**)
+    2. Haga clic en {% icon galaxy-columns %} **Mostrar Historias lado a lado**
     3. Si el historial de destino no está presente
         1. Haga clic en "Seleccionar historiales
         2. Haga clic en el historial de destino

--- a/faqs/galaxy-es/tools_change_version.md
+++ b/faqs/galaxy-es/tools_change_version.md
@@ -12,6 +12,6 @@ Las herramientas se actualizan con frecuencia a nuevas versiones. Su Galaxy pued
 
 **Pasar a otra versión** de una herramienta:
   - Abrir la herramienta
-  - Haga clic en el logo {% icono herramienta-versiones %} versiones arriba a la derecha**
+  - Haga clic en el logo {% icon tool-versions %} versiones arriba a la derecha**
   - Seleccione la versión deseada en la lista desplegable
 

--- a/faqs/galaxy-es/tools_select_collection.md
+++ b/faqs/galaxy-es/tools_select_collection.md
@@ -11,6 +11,6 @@ contributors:
 
 
 
-1. Haga clic en {% icono param-collection %} **Dataset collection** delante del parámetro de entrada al que desea suministrar la colección.
+1. Haga clic en {% icon param-collection %} **Dataset collection** delante del parámetro de entrada al que desea suministrar la colección.
 2. Seleccione la colección que desea utilizar de la lista
 

--- a/faqs/galaxy-es/tools_select_multiple_datasets.md
+++ b/faqs/galaxy-es/tools_select_multiple_datasets.md
@@ -11,6 +11,6 @@ contributors:
 ---
 
 
-1. Haga clic en {% icono param-files %} **Conjuntos de datos múltiples**
+1. Haga clic en {% icon param-files %} **Conjuntos de datos múltiples**
 2. Selecciona varios archivos manteniendo pulsada la tecla <kbd>Ctrl</kbd> (o <kbd>COMMAND</kbd>) y haciendo clic en los archivos que te interesen
 

--- a/faqs/galaxy-it/datasets_change_datatype.md
+++ b/faqs/galaxy-it/datasets_change_datatype.md
@@ -22,7 +22,7 @@ examples:
 ---
 
 
-* Cliccare sull'icona {% galaxy-pencil %} **icona della matita** per il set di dati per modificarne gli attributi
+* Cliccare sull'icona {% icon galaxy-pencil %} **icona della matita** per il set di dati per modificarne gli attributi
 * Nel pannello centrale, fare clic su {% icon galaxy-chart-select-data %} *scheda *Datipi** in alto
 * Nella sezione {% icon galaxy-chart-select-data %} **Assegna tipo di dato**, selezionare {% if include.datatype %}`{{ include.datatype }}`{% else %} il tipo di dato desiderato {% endif %} dal menu a discesa "*Nuovo tipo*"
   - Suggerimento: si può iniziare a digitare il tipo di dato nel campo per filtrare il menu a discesa

--- a/faqs/galaxy-it/datasets_create_new_file.md
+++ b/faqs/galaxy-it/datasets_create_new_file.md
@@ -25,12 +25,12 @@ examples:
 ---
 
 
-* Fare clic su {% icona galaxy-upload %} **Caricamento dati** nella parte superiore del pannello degli strumenti
-* Selezionare {% icona galaxy-wf-edit %} **Incolla/Recupera dati** in basso
+* Fare clic su {% icon galaxy-upload %} **Caricamento dati** nella parte superiore del pannello degli strumenti
+* Selezionare {% icon galaxy-wf-edit %} **Incolla/Recupera dati** in basso
 * Incollare il contenuto del file nel campo di testo {% if include.name %}
 * Cambiare il nome del dataset da "New File" a `{{ include.name }}` {% endif %} {%- if include.format -%}
 * Cambiare **Type** da "Auto-detect" a `{{ include.format }}` {%- endif -%} {%- if include.genome -%}
 * Cambiare **Genome** in `{{ include.genome }}` {%- endif -%} {%- if include.convertspaces -%}
-* Dal menu Impostazioni ({% icona galaxy-gear %}) selezionare **Converti spazi in tabulazioni** {%- endif -%}
+* Dal menu Impostazioni ({% icon galaxy-gear %}) selezionare **Converti spazi in tabulazioni** {%- endif -%}
 * Premere **Avvio** e **Chiudere** la finestra
 

--- a/faqs/galaxy-it/datasets_import_from_data_library.md
+++ b/faqs/galaxy-it/datasets_import_from_data_library.md
@@ -16,9 +16,9 @@ contributors:
 In alternativa al caricamento dei dati da un URL o dal proprio computer, i file possono essere resi disponibili da una libreria di dati condivisi:
 
 1. Entrare in **Librerie** (pannello sinistro)
-2. Navigare verso {% if include.path %}: *{{ include.path }}* o {% endif %} alla cartella corretta indicata dal vostro istruttore. {Nella maggior parte dei Galaxies i dati delle esercitazioni vengono forniti in una cartella denominata **GTN - Materiale --> Nome argomento -> Nome esercitazione**. {% endunless %}
+2. Navigare verso {% if include.path %}: *{{ include.path }}* o {% endif %} alla cartella corretta indicata dal vostro istruttore. {% unless include.path %} Nella maggior parte dei Galaxies i dati delle esercitazioni vengono forniti in una cartella denominata **GTN - Materiale --> Nome argomento -> Nome esercitazione**. {% endunless %}
 3. selezionare i file desiderati
-4. Fare clic su **Aggiungi alla cronologia** {% icona galaxy-dropdown %} vicino alla parte superiore e selezionare **{{ include.astype | default: "as Datasets" }}** dal menu a tendina
+4. Fare clic su **Aggiungi alla cronologia** {% icon galaxy-dropdown %} vicino alla parte superiore e selezionare **{{ include.astype | default: "as Datasets" }}** dal menu a tendina
 5. Nella finestra pop-up, scegliere {% if include.collection_type %}
    * *"Tipo di raccolta "*: **{{ include.collection_type }}** {% endif %}
    * *"Seleziona cronologia "*: {% if include.tohistory %}{{ include.tohistory }}{% else %} la cronologia in cui si desidera importare i dati (o crearne una nuova){% endif %}

--- a/faqs/galaxy-it/datasets_import_via_link.md
+++ b/faqs/galaxy-it/datasets_import_via_link.md
@@ -44,11 +44,11 @@ examples:
 
 
 * Copia la posizione del collegamento
-* Fare clic su {% icona galaxy-upload %} **Carica i dati** nella parte superiore del pannello degli strumenti {% if include.reset_form %}
+* Fare clic su {% icon galaxy-upload %} **Carica i dati** nella parte superiore del pannello degli strumenti {% if include.reset_form %}
 * Fare clic sul pulsante **Reset** in fondo al modulo. Se il pulsante è grigio -> passare al passo successivo. {% endif %} {% if include.collection %}
 * Fare clic su **Collection** in alto {% endif %} {% if include.collection_type %}
 * Fare clic su **Tipo di raccolta** e selezionare `{{ include.collection_type }}` {% endif %}
-* Selezionare {% icona galaxy-wf-edit %} **Incollare/recuperare i dati**
+* Selezionare {% icon galaxy-wf-edit %} **Incollare/recuperare i dati**
 * Incollare il/i link nel campo di testo {% if include.link %} `{{ include.link }}` {% endif %} {% if include.link2 %} `{{ include.link2 }}` {% endif %} {% if include.format %}
 * Cambiare **Type (set all):** da "Auto-detect" a `{{ include.format }}` {% endif %} {% if include.genome %}
 * Cambiare **Genome** in `{{ include.genome }}` {% endif %}

--- a/faqs/galaxy-it/datasets_rename.md
+++ b/faqs/galaxy-it/datasets_rename.md
@@ -18,7 +18,7 @@ examples:
 ---
 
 
-- Fare clic sull'icona {% galaxy-pencil %} **icona della matita** per il set di dati per modificarne gli attributi
+- Fare clic sull'icona {% icon galaxy-pencil %} **icona della matita** per il set di dati per modificarne gli attributi
 - Nel pannello centrale, cambiare il campo **Name** {% if include.name %} in `{{ include.name }}` {% endif %}
 - Fare clic sul pulsante **Save**
 

--- a/faqs/galaxy-it/features_scratchbook.md
+++ b/faqs/galaxy-it/features_scratchbook.md
@@ -10,15 +10,15 @@ contributors:
 
 
 Se si desidera visualizzare due o più insiemi di dati contemporaneamente, è possibile utilizzare la funzione **Window Manager** di Galaxy:
-  1. **Cliccare** sull'icona *Gestore finestre* {% icona galaxy-scratchbook%} nella barra dei menu superiore.
+  1. **Cliccare** sull'icona *Gestore finestre* {% icon galaxy-scratchbook%} nella barra dei menu superiore.
      - ora dovrebbe comparire un piccolo segno di spunta sull'icona
-  2. **Visualizza** {% icona galassia-occhio %} un set di dati facendo clic sull'icona occhio {% icona galassia-occhio %} per visualizzare l'output
+  2. **Visualizza** {% icon galaxy-eye %} un set di dati facendo clic sull'icona occhio {% icon galaxy-eye %} per visualizzare l'output
      - Si dovrebbe vedere l'output in una finestra sovrapposta a Galaxy
      - È possibile ridimensionare questa finestra trascinando l'angolo in basso a destra
   3. **Cliccare** all'esterno del file per uscire dal gestore delle finestre
-  4. **Visualizza** {% icona galaxy-eye %} un secondo set di dati dalla tua cronologia
+  4. **Visualizza** {% icon galaxy-eye %} un secondo set di dati dalla tua cronologia
      - Si dovrebbe ora vedere una seconda finestra con il nuovo set di dati
      - In questo modo è più facile confrontare i due output
   5. Ripetere l'operazione per il numero di file che si desidera confrontare
-  6. È possibile disattivare il **Gestore finestre** {% icona galaxy-scratchbook %} facendo di nuovo clic sull'icona
+  6. È possibile disattivare il **Gestore finestre** {% icon galaxy-scratchbook %} facendo di nuovo clic sull'icona
 

--- a/faqs/galaxy-it/histories_copy_dataset.md
+++ b/faqs/galaxy-it/histories_copy_dataset.md
@@ -18,7 +18,7 @@ Esistono 3 modi per copiare i set di dati tra le cronologie
 
 1. Dalla cronologia originale
 
-    1. Cliccare sull'icona {% icona galaxy-gear %} che si trova in cima all'elenco dei dataset nel pannello della cronologia
+    1. Cliccare sull'icona {% icon galaxy-gear %} che si trova in cima all'elenco dei dataset nel pannello della cronologia
     2. Fare clic su **Copia set di dati**
     3. Selezionare i file desiderati {% if include.history_name %}
     4. "Nuova cronologia denominata:" `{{ include.history_name }}` {% else %}
@@ -26,10 +26,10 @@ Esistono 3 modi per copiare i set di dati tra le cronologie
     5. Convalida per 'Copia elementi della cronologia'
     5. Fare clic sul nome della nuova cronologia nel riquadro verde appena visualizzato per passare a questa cronologia
 
-2. Utilizzo dell'icona {% galassia-colonne %} **Mostra le cronologie affiancate**
+2. Utilizzo dell'icona {% icon galaxy-columns %} **Mostra le cronologie affiancate**
 
-    1. Fare clic sulla freccia a discesa {% icona galaxy-dropdown %} in alto a destra del pannello della cronologia (**opzioni cronologia**)
-    2. Cliccare su {% icona galassia-colonne %} **Mostra le cronologie affiancate**
+    1. Fare clic sulla freccia a discesa {% icon galaxy-dropdown %} in alto a destra del pannello della cronologia (**opzioni cronologia**)
+    2. Cliccare su {% icon galaxy-columns %} **Mostra le cronologie affiancate**
     3. se la cronologia di destinazione non è presente
         1. Fare clic su "Seleziona cronologia"
         2. Fare clic sulla cronologia di destinazione

--- a/faqs/galaxy-it/histories_create_new.md
+++ b/faqs/galaxy-it/histories_create_new.md
@@ -17,7 +17,7 @@ contributors:
 ---
 
 
-Per creare una nuova storia è sufficiente fare clic sull'icon {% icon new-history %} nella parte superiore del pannello della storia:
+Per creare una nuova storia è sufficiente fare clic sull'icona {% icon new-history %} nella parte superiore del pannello della storia:
 
 ![UI per la creazione di una nuova storia]({% link shared/images/history_create_new.svg %})
 

--- a/faqs/galaxy-it/histories_create_new.md
+++ b/faqs/galaxy-it/histories_create_new.md
@@ -17,7 +17,7 @@ contributors:
 ---
 
 
-Per creare una nuova storia è sufficiente fare clic sull'icona {% icona nuova-storia %} nella parte superiore del pannello della storia:
+Per creare una nuova storia è sufficiente fare clic sull'icon {% icon new-history %} nella parte superiore del pannello della storia:
 
 ![UI per la creazione di una nuova storia]({% link shared/images/history_create_new.svg %})
 

--- a/faqs/galaxy-it/histories_rename.md
+++ b/faqs/galaxy-it/histories_rename.md
@@ -13,12 +13,12 @@ contributors:
 ---
 
 
-1. Fare clic su {% icona galassia-matita %} (**Modifica**) accanto al nome della storia (che per impostazione predefinita è "Storia senza nome")
+1. Fare clic su {% icon galaxy-pencil %} (**Modifica**) accanto al nome della storia (che per impostazione predefinita è "Storia senza nome")
 2. Digitare il nuovo nome{% if include.name %}: `{{ include.name }}`{% endif %}
 3. fare clic su **Salva**
-4. Per annullare la ridenominazione, fare clic sul pulsante {% icona galaxy-undo %} "Annulla"
+4. Per annullare la ridenominazione, fare clic sul pulsante {% icon galaxy-undo %} "Annulla"
 
-Se non si ha l'icona {% galaxy-pencil %} (**Modifica**) accanto al nome della cronologia (cosa che può accadere se si utilizza una versione precedente di Galaxy), procedere come segue:
+Se non si ha l'icona {% icon galaxy-pencil %} (**Modifica**) accanto al nome della cronologia (cosa che può accadere se si utilizza una versione precedente di Galaxy), procedere come segue:
 
 1. Fare clic su **Cronologia senza nome** (o sul nome attuale della cronologia) (**Clicca per rinominare la cronologia**) nella parte superiore del pannello della cronologia
 2. Digitare il nuovo nome{% if include.name %}: `{{ include.name }}`{% endif %}

--- a/faqs/galaxy-it/tools_change_version.md
+++ b/faqs/galaxy-it/tools_change_version.md
@@ -12,6 +12,6 @@ Gli strumenti vengono aggiornati frequentemente con nuove versioni. Nella vostra
 
 **Passaggio a una versione** diversa di uno strumento:
   - aprire lo strumento
-  - Fare clic sul logo {% icona strumento-versioni %} versioni in **alto a destra**
+  - Fare clic sul logo {% icon tool-versions %} versioni in **alto a destra**
   - Selezionare la versione desiderata dall'elenco a discesa
 

--- a/faqs/galaxy-it/tools_select_multiple_datasets.md
+++ b/faqs/galaxy-it/tools_select_multiple_datasets.md
@@ -11,6 +11,6 @@ contributors:
 ---
 
 
-1. Fare clic su {% icona param-files %} **Insiemi di dati multipli**
+1. Fare clic su {% icon param-files %} **Insiemi di dati multipli**
 2. Selezionare diversi file tenendo premuto il tasto <kbd>Ctrl</kbd> (o <kbd>COMMAND</kbd>) e facendo clic sui file di interesse
 


### PR DESCRIPTION
With the last commit "make preview" fails because the AI translated snipped metadata like tags or icon names. With this corrections  compiles properly
